### PR TITLE
Fix capitalization in call to App class.

### DIFF
--- a/v2/app/index.php
+++ b/v2/app/index.php
@@ -2,7 +2,7 @@
 require_once $_SERVER['DOCUMENT_ROOT'] . '/orthanc/includes/include.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/orthanc/includes/token.php';
 
-$app = new app();
+$app = new App();
 
 /**
  * Get_amount_by_id returns the the amount of sonuren someone has based on character ID


### PR DESCRIPTION
Should fix error: 
```
<br />
<b>Warning</b>:  include(classes/app.php): failed to open stream: No such file or directory in <b>/home/ubuntu/eos_apps/api.dev2/orthanc/includes/include.php</b> on line <b>25</b><br />
<br />
<b>Warning</b>:  include(): Failed opening 'classes/app.php' for inclusion (include_path='.:/usr/share/php') in <b>/home/ubuntu/eos_apps/api.dev2/orthanc/includes/include.php</b> on line <b>25</b><br />
<br />
<b>Fatal error</b>:  Uncaught Error: Class 'app' not found in /home/ubuntu/eos_apps/api.dev2/orthanc/v2/app/index.php:5
Stack trace:
#0 {main}
  thrown in <b>/home/ubuntu/eos_apps/api.dev2/orthanc/v2/app/index.php</b> on line <b>5</b><br />
```