### PR TITLE
Add IssueToken and RevokeToken artisan commands

### DIFF
--- a/v3/app/Console/Commands/IssueToken.php
+++ b/v3/app/Console/Commands/IssueToken.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\TokenAbility;
+use App\Models\ApiConsumer;
+use Illuminate\Console\Command;
+
+/**
+ * Artisan command to issue a Sanctum API token for an ApiConsumer.
+ *
+ * Creates the consumer if it does not already exist, then generates
+ * a token with the specified ability scopes. The plain-text token
+ * is printed as the last line of output for easy scripting.
+ */
+class IssueToken extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'orthanc:issue-token {name} {--abilities=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Issue a Sanctum API token for an API consumer';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+        $abilitiesOption = $this->option('abilities');
+
+        if (empty($abilitiesOption)) {
+            $this->error('The --abilities option is required and must not be empty.');
+            return self::FAILURE;
+        }
+
+        $abilities = array_map('trim', explode(',', $abilitiesOption));
+        $validAbilities = TokenAbility::values();
+        $invalid = array_diff($abilities, $validAbilities);
+
+        if (! empty($invalid)) {
+            $this->error('Invalid abilities: ' . implode(', ', $invalid));
+            $this->error('Valid abilities: ' . implode(', ', $validAbilities));
+            return self::FAILURE;
+        }
+
+        $consumer = ApiConsumer::firstOrCreate(
+            ['name' => $name],
+            ['created_at' => time()],
+        );
+
+        $token = $consumer->createToken($name, $abilities);
+
+        $this->info("Consumer: {$consumer->name}");
+        $this->info('Abilities: ' . implode(', ', $abilities));
+        $this->info("Token ID: {$token->accessToken->id}");
+        $this->line($token->plainTextToken);
+
+        return self::SUCCESS;
+    }
+}

--- a/v3/app/Console/Commands/RevokeToken.php
+++ b/v3/app/Console/Commands/RevokeToken.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ApiConsumer;
+use Illuminate\Console\Command;
+
+/**
+ * Artisan command to revoke a Sanctum API token for an ApiConsumer.
+ *
+ * Looks up the consumer by name and the token by ID, ensuring the token
+ * belongs to that consumer before deleting it.
+ */
+class RevokeToken extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'orthanc:revoke-token {name} {token_id}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Revoke a Sanctum API token for an API consumer';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+        $tokenId = $this->argument('token_id');
+
+        $consumer = ApiConsumer::where('name', $name)->first();
+
+        if (! $consumer) {
+            $this->error("Consumer '{$name}' not found.");
+            return self::FAILURE;
+        }
+
+        $token = $consumer->tokens()->where('id', $tokenId)->first();
+
+        if (! $token) {
+            $this->error("Token #{$tokenId} not found for consumer '{$name}'.");
+            return self::FAILURE;
+        }
+
+        $token->delete();
+
+        $this->info("Token #{$tokenId} for consumer '{$name}' has been revoked.");
+
+        return self::SUCCESS;
+    }
+}

--- a/v3/tests/Feature/Console/Commands/TokenCommandsTest.php
+++ b/v3/tests/Feature/Console/Commands/TokenCommandsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Models\ApiConsumer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TokenCommandsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_issue_token_creates_consumer_and_token(): void
+    {
+        $this->artisan('orthanc:issue-token', [
+            'name' => 'test-consumer',
+            '--abilities' => 'storage:read',
+        ])->assertExitCode(0);
+
+        $this->assertDatabaseHas('api_consumers', ['name' => 'test-consumer']);
+        $this->assertDatabaseCount('personal_access_tokens', 1);
+    }
+
+    public function test_issue_token_reuses_existing_consumer(): void
+    {
+        ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+
+        $this->artisan('orthanc:issue-token', [
+            'name' => 'test-consumer',
+            '--abilities' => 'storage:read',
+        ])->assertExitCode(0);
+
+        $this->assertDatabaseCount('api_consumers', 1);
+    }
+
+    public function test_issue_token_last_line_is_plain_token(): void
+    {
+        $this->artisan('orthanc:issue-token', [
+            'name' => 'test-consumer',
+            '--abilities' => 'storage:read',
+        ])->expectsOutputToContain('|')
+          ->assertExitCode(0);
+    }
+
+    public function test_issue_token_fails_with_invalid_ability(): void
+    {
+        $this->artisan('orthanc:issue-token', [
+            'name' => 'test-consumer',
+            '--abilities' => 'storage:read,invalid:perm',
+        ])->assertFailed();
+    }
+
+    public function test_issue_token_fails_without_abilities(): void
+    {
+        $this->artisan('orthanc:issue-token', [
+            'name' => 'test-consumer',
+        ])->assertFailed();
+    }
+
+    public function test_revoke_token_deletes_token(): void
+    {
+        $consumer = ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+        $token = $consumer->createToken('test', ['storage:read']);
+
+        $this->artisan('orthanc:revoke-token', [
+            'name' => 'test-consumer',
+            'token_id' => $token->accessToken->id,
+        ])->assertExitCode(0);
+
+        $this->assertDatabaseCount('personal_access_tokens', 0);
+    }
+
+    public function test_revoke_token_fails_for_nonexistent_consumer(): void
+    {
+        $this->artisan('orthanc:revoke-token', [
+            'name' => 'ghost',
+            'token_id' => 999,
+        ])->assertFailed();
+    }
+
+    public function test_revoke_token_fails_for_wrong_consumer(): void
+    {
+        $owner = ApiConsumer::create(['name' => 'owner', 'created_at' => time()]);
+        ApiConsumer::create(['name' => 'other', 'created_at' => time()]);
+        $token = $owner->createToken('test', ['storage:read']);
+
+        $this->artisan('orthanc:revoke-token', [
+            'name' => 'other',
+            'token_id' => $token->accessToken->id,
+        ])->assertFailed();
+
+        // Token should still exist
+        $this->assertDatabaseCount('personal_access_tokens', 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `orthanc:issue-token` command: creates/reuses an `ApiConsumer`, validates abilities against `TokenAbility::values()`, outputs the plain-text token as the last line for scripting
- Add `orthanc:revoke-token` command: finds consumer by name, deletes the specified token (scoped to that consumer only)
- Add 8 feature tests covering creation, reuse, output format, validation failures, revocation, and cross-consumer protection

Closes #72

## Test plan

- [x] `php artisan test --filter=TokenCommandsTest` — all 8 tests pass
- [ ] Smoke test (requires migrated DB): `TOKEN=$(php artisan orthanc:issue-token "smoke-test" --abilities=storage:read | tail -1) && echo $TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)