### PR TITLE
Add ecc_storage_* table migrations and seeders

### DIFF
--- a/v3/database/migrations/2026_03_27_000010_create_ecc_storage_categories_table.php
+++ b/v3/database/migrations/2026_03_27_000010_create_ecc_storage_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create the ecc_storage_categories table for item type grouping.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+        Schema::create('ecc_storage_categories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 100)->unique();
+            $table->unsignedInteger('created_at');
+            $table->unsignedInteger('created_by');
+            $table->unsignedInteger('deleted_at')->nullable();
+            $table->tinyInteger('is_system')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migration.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ecc_storage_categories');
+    }
+};

--- a/v3/database/migrations/2026_03_27_000011_create_ecc_storage_item_types_table.php
+++ b/v3/database/migrations/2026_03_27_000011_create_ecc_storage_item_types_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create the ecc_storage_item_types table for defining storable items.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+        Schema::create('ecc_storage_item_types', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 100)->unique();
+            $table->text('description')->nullable();
+            $table->string('icon', 100)->nullable();
+            $table->unsignedInteger('category_id');
+            $table->tinyInteger('stackable')->default(1);
+            $table->unsignedInteger('max_quantity')->nullable();
+            $table->tinyInteger('is_system')->default(0);
+            $table->unsignedInteger('created_at');
+            $table->unsignedInteger('created_by');
+            $table->unsignedInteger('updated_at')->nullable();
+            $table->unsignedInteger('deleted_at')->nullable();
+
+            $table->foreign('category_id', 'fk_item_type_category')
+                ->references('id')
+                ->on('ecc_storage_categories');
+        });
+    }
+
+    /**
+     * Reverse the migration.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ecc_storage_item_types');
+    }
+};

--- a/v3/database/migrations/2026_03_27_000012_create_ecc_storage_inventory_table.php
+++ b/v3/database/migrations/2026_03_27_000012_create_ecc_storage_inventory_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create the ecc_storage_inventory table for character item balances.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+        Schema::create('ecc_storage_inventory', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('character_id');
+            $table->unsignedInteger('item_type_id');
+            $table->integer('quantity')->default(0);
+            $table->unsignedInteger('updated_at');
+
+            $table->unique(['character_id', 'item_type_id'], 'uq_char_item');
+        });
+    }
+
+    /**
+     * Reverse the migration.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ecc_storage_inventory');
+    }
+};

--- a/v3/database/migrations/2026_03_27_000013_create_ecc_storage_log_table.php
+++ b/v3/database/migrations/2026_03_27_000013_create_ecc_storage_log_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create the ecc_storage_log table for append-only audit trail.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+        Schema::create('ecc_storage_log', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('item_type_id');
+            $table->integer('quantity');
+            $table->unsignedInteger('source_char_id')->nullable();
+            $table->unsignedInteger('target_char_id')->nullable();
+            $table->unsignedInteger('actor_joomla_id');
+            $table->string('action', 30);
+            $table->tinyInteger('brokered')->default(0);
+            $table->string('note', 255)->nullable();
+            $table->unsignedInteger('created_at');
+
+            $table->index(['source_char_id', 'created_at'], 'idx_source_char');
+            $table->index(['target_char_id', 'created_at'], 'idx_target_char');
+            $table->index(['item_type_id', 'created_at'], 'idx_item_type');
+        });
+    }
+
+    /**
+     * Reverse the migration.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ecc_storage_log');
+    }
+};

--- a/v3/database/migrations/2026_03_27_000014_create_ecc_storage_settings_table.php
+++ b/v3/database/migrations/2026_03_27_000014_create_ecc_storage_settings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create the ecc_storage_settings table for runtime configuration.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+        Schema::create('ecc_storage_settings', function (Blueprint $table) {
+            $table->string('key_name', 50)->primary();
+            $table->string('value', 255);
+            $table->unsignedInteger('updated_at');
+            $table->unsignedInteger('updated_by');
+        });
+    }
+
+    /**
+     * Reverse the migration.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ecc_storage_settings');
+    }
+};

--- a/v3/database/seeders/DatabaseSeeder.php
+++ b/v3/database/seeders/DatabaseSeeder.php
@@ -2,10 +2,12 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
+/**
+ * Main database seeder that calls all storage seeders.
+ */
 class DatabaseSeeder extends Seeder
 {
     use WithoutModelEvents;
@@ -15,11 +17,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            StorageCategorySeeder::class,
+            StorageItemTypeSeeder::class,
+            StorageSettingsSeeder::class,
         ]);
     }
 }

--- a/v3/database/seeders/StorageCategorySeeder.php
+++ b/v3/database/seeders/StorageCategorySeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seed the Currency category into ecc_storage_categories.
+ */
+class StorageCategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('ecc_storage_categories')->insertOrIgnore([
+            'id' => 1,
+            'name' => 'Currency',
+            'created_at' => time(),
+            'created_by' => 0,
+            'is_system' => 1,
+        ]);
+    }
+}

--- a/v3/database/seeders/StorageItemTypeSeeder.php
+++ b/v3/database/seeders/StorageItemTypeSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seed the Sonuren item type into ecc_storage_item_types.
+ */
+class StorageItemTypeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('ecc_storage_item_types')->insertOrIgnore([
+            'id' => 1,
+            'name' => 'Sonuren',
+            'description' => 'In-game currency',
+            'category_id' => 1,
+            'stackable' => 1,
+            'is_system' => 1,
+            'created_at' => time(),
+            'created_by' => 0,
+        ]);
+    }
+}

--- a/v3/database/seeders/StorageSettingsSeeder.php
+++ b/v3/database/seeders/StorageSettingsSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seed default settings into ecc_storage_settings.
+ */
+class StorageSettingsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('ecc_storage_settings')->insertOrIgnore([
+            'key_name' => 'transfers_enabled',
+            'value' => '1',
+            'updated_at' => time(),
+            'updated_by' => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 5 migrations for `ecc_storage_categories`, `ecc_storage_item_types`, `ecc_storage_inventory`, `ecc_storage_log`, and `ecc_storage_settings` tables
- Add seeders for Currency category, Sonuren item type, and `transfers_enabled` setting
- Update `DatabaseSeeder` to call all three storage seeders (removed broken User factory reference)

Closes #73, Closes #74, Closes #75, Closes #76, Closes #77

## Test plan
- [ ] `php artisan migrate` — all 5 tables created
- [ ] `php artisan db:seed` — Currency, Sonuren, transfers_enabled inserted
- [ ] `php artisan migrate:rollback` — all tables dropped cleanly
- [ ] Re-run migrate + seed to confirm idempotent
- [ ] Verify FK constraint: inserting item_type with invalid category_id fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)