### PR TITLE
Add Eloquent models for ecc_storage_* tables

### DIFF
--- a/v3/app/Models/StorageCategory.php
+++ b/v3/app/Models/StorageCategory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * A top-level grouping for storage item types.
+ *
+ * Categories organise item types into logical groups (e.g. "Weapons",
+ * "Resources") and can be soft-deleted via the `deleted_at` epoch column.
+ */
+class StorageCategory extends Model
+{
+    protected $table = 'ecc_storage_categories';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'name',
+        'created_at',
+        'created_by',
+        'deleted_at',
+        'is_system',
+    ];
+
+    protected $casts = [
+        'created_at' => 'integer',
+        'created_by' => 'integer',
+        'deleted_at' => 'integer',
+        'is_system'  => 'boolean',
+    ];
+
+    /**
+     * Scope to only non-deleted categories.
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereNull('deleted_at');
+    }
+
+    /**
+     * The item types that belong to this category.
+     */
+    public function itemTypes(): HasMany
+    {
+        return $this->hasMany(StorageItemType::class, 'category_id');
+    }
+}

--- a/v3/app/Models/StorageInventory.php
+++ b/v3/app/Models/StorageInventory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A row in a character's inventory, linking a character to an item type
+ * with a specific quantity.
+ */
+class StorageInventory extends Model
+{
+    protected $table = 'ecc_storage_inventory';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'character_id',
+        'item_type_id',
+        'quantity',
+        'updated_at',
+    ];
+
+    protected $casts = [
+        'character_id' => 'integer',
+        'item_type_id' => 'integer',
+        'quantity'     => 'integer',
+        'updated_at'   => 'integer',
+    ];
+
+    /**
+     * The item type for this inventory row.
+     */
+    public function itemType(): BelongsTo
+    {
+        return $this->belongsTo(StorageItemType::class, 'item_type_id');
+    }
+}

--- a/v3/app/Models/StorageItemType.php
+++ b/v3/app/Models/StorageItemType.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A type of item that can be stored in character inventories.
+ *
+ * Item types define the properties shared by all instances of a particular
+ * item, such as whether it is stackable and its maximum stack quantity.
+ */
+class StorageItemType extends Model
+{
+    protected $table = 'ecc_storage_item_types';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'icon',
+        'category_id',
+        'stackable',
+        'max_quantity',
+        'is_system',
+        'created_at',
+        'created_by',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    protected $casts = [
+        'category_id'  => 'integer',
+        'stackable'    => 'boolean',
+        'max_quantity'  => 'integer',
+        'is_system'    => 'boolean',
+        'created_at'   => 'integer',
+        'created_by'   => 'integer',
+        'updated_at'   => 'integer',
+        'deleted_at'   => 'integer',
+    ];
+
+    /**
+     * Scope to only non-deleted item types.
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereNull('deleted_at');
+    }
+
+    /**
+     * The category this item type belongs to.
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(StorageCategory::class, 'category_id');
+    }
+}

--- a/v3/app/Models/StorageLabelToken.php
+++ b/v3/app/Models/StorageLabelToken.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A single-use token printed on a physical label that can be claimed
+ * by a character to receive items.
+ */
+class StorageLabelToken extends Model
+{
+    protected $table = 'ecc_storage_label_tokens';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'token',
+        'item_type_id',
+        'quantity',
+        'note',
+        'source',
+        'source_char_id',
+        'created_by',
+        'created_at',
+        'claimed_by',
+        'claimed_at',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'item_type_id'   => 'integer',
+        'quantity'       => 'integer',
+        'source_char_id' => 'integer',
+        'created_by'     => 'integer',
+        'created_at'     => 'integer',
+        'claimed_by'     => 'integer',
+        'claimed_at'     => 'integer',
+        'expires_at'     => 'integer',
+    ];
+
+    /**
+     * Scope to only tokens that have not yet been claimed.
+     */
+    public function scopeUnclaimed(Builder $query): Builder
+    {
+        return $query->whereNull('claimed_by');
+    }
+
+    /**
+     * The item type this label token grants.
+     */
+    public function itemType(): BelongsTo
+    {
+        return $this->belongsTo(StorageItemType::class, 'item_type_id');
+    }
+}

--- a/v3/app/Models/StorageLog.php
+++ b/v3/app/Models/StorageLog.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * An audit-trail entry recording a storage transaction.
+ *
+ * Every transfer, grant, or removal of items generates a log row that
+ * captures the involved characters, quantity, and action type.
+ */
+class StorageLog extends Model
+{
+    protected $table = 'ecc_storage_log';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'item_type_id',
+        'quantity',
+        'source_char_id',
+        'target_char_id',
+        'actor_joomla_id',
+        'action',
+        'brokered',
+        'note',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'item_type_id'    => 'integer',
+        'quantity'        => 'integer',
+        'source_char_id'  => 'integer',
+        'target_char_id'  => 'integer',
+        'actor_joomla_id' => 'integer',
+        'brokered'        => 'boolean',
+        'created_at'      => 'integer',
+    ];
+
+    /**
+     * The item type involved in this log entry.
+     */
+    public function itemType(): BelongsTo
+    {
+        return $this->belongsTo(StorageItemType::class, 'item_type_id');
+    }
+}

--- a/v3/app/Models/StorageSetting.php
+++ b/v3/app/Models/StorageSetting.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A key-value configuration setting for the storage system.
+ *
+ * Uses a string primary key (`key_name`) instead of an auto-incrementing
+ * integer ID.
+ */
+class StorageSetting extends Model
+{
+    protected $table = 'ecc_storage_settings';
+
+    protected $primaryKey = 'key_name';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'key_name',
+        'value',
+        'updated_at',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'updated_at' => 'integer',
+        'updated_by' => 'integer',
+    ];
+}


### PR DESCRIPTION
## Summary
- Add 6 Eloquent models: `StorageCategory`, `StorageItemType`, `StorageInventory`, `StorageLog`, `StorageSetting`, `StorageLabelToken`
- All follow established pattern: `$timestamps = false`, explicit `$table`, integer casts for Unix epoch columns, PHPDoc blocks
- Scopes (`active`, `unclaimed`) and relations (`hasMany`, `belongsTo`) wired up per spec

## Test plan
- [x] `php artisan test` — all 17 existing tests pass

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)