### PR TITLE
Add API Resources and FormRequests for storage system

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -421,8 +421,8 @@ ORDER BY created_at DESC LIMIT 50 OFFSET 0
 - [x] V3-DB-05 ([orthanc#78](https://github.com/eosfrontier/orthanc/issues/78)): Write rollback SQL
 
 ### Step 4 — Models + Resources + FormRequests ([orthanc#100](https://github.com/eosfrontier/orthanc/issues/100))
-- [ ] V3-05 ([orthanc#82](https://github.com/eosfrontier/orthanc/issues/82)): All Eloquent models (`$timestamps = false`, explicit table names, scopes, relations): `StorageCategory`, `StorageItemType`, `StorageInventory`, `StorageLog`, `StorageSetting`, `StorageLabelToken`
-- [ ] V3-06 ([orthanc#83](https://github.com/eosfrontier/orthanc/issues/83)): All API Resources (one per model) + all FormRequests (one per write operation)
+- [x] V3-05 ([orthanc#82](https://github.com/eosfrontier/orthanc/issues/82)): All Eloquent models (`$timestamps = false`, explicit table names, scopes, relations): `StorageCategory`, `StorageItemType`, `StorageInventory`, `StorageLog`, `StorageSetting`, `StorageLabelToken`
+- [x] V3-06 ([orthanc#83](https://github.com/eosfrontier/orthanc/issues/83)): All API Resources (one per model) + all FormRequests (one per write operation)
 
 ### Step 5 — Services ([orthanc#101](https://github.com/eosfrontier/orthanc/issues/101))
 - [ ] V3-07 ([orthanc#84](https://github.com/eosfrontier/orthanc/issues/84)): `InventoryService` — mint/burn/adjust/bulk inside `DB::transaction()`; `max_quantity` cap (422) + unit tests

--- a/v3/app/Http/Requests/AdjustInventoryRequest.php
+++ b/v3/app/Http/Requests/AdjustInventoryRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates a request to adjust (delta) a character's inventory quantity.
+ */
+class AdjustInventoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'quantity'        => 'required|integer',
+            'actor_joomla_id' => 'required|integer',
+            'note'           => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/BulkMintInventoryRequest.php
+++ b/v3/app/Http/Requests/BulkMintInventoryRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a request to mint items into multiple characters' inventories at once.
+ */
+class BulkMintInventoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'item_type_id' => [
+                'required',
+                'integer',
+                Rule::exists('ecc_storage_item_types', 'id')->whereNull('deleted_at'),
+            ],
+            'quantity'        => 'required|integer|min:1',
+            'character_ids'   => 'required|array|max:200',
+            'character_ids.*' => 'integer',
+            'actor_joomla_id' => 'required|integer',
+            'note'           => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/ClaimLabelTokenRequest.php
+++ b/v3/app/Http/Requests/ClaimLabelTokenRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates a request to claim a label token for a character.
+ */
+class ClaimLabelTokenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'token'           => 'required|string|size:36',
+            'character_id'    => 'required|integer',
+            'actor_joomla_id' => 'required|integer',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/MintInventoryRequest.php
+++ b/v3/app/Http/Requests/MintInventoryRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a request to mint (grant) items into a character's inventory.
+ */
+class MintInventoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'character_id'   => 'required|integer',
+            'item_type_id'   => [
+                'required',
+                'integer',
+                Rule::exists('ecc_storage_item_types', 'id')->whereNull('deleted_at'),
+            ],
+            'quantity'        => 'required|integer|min:1',
+            'actor_joomla_id' => 'required|integer',
+            'note'           => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/StoreCategoryRequest.php
+++ b/v3/app/Http/Requests/StoreCategoryRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates a request to create a new storage category.
+ */
+class StoreCategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:100|unique:ecc_storage_categories,name',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/StoreItemTypeRequest.php
+++ b/v3/app/Http/Requests/StoreItemTypeRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a request to create a new storage item type.
+ */
+class StoreItemTypeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name'         => 'required|string|max:100|unique:ecc_storage_item_types,name',
+            'category_id'  => [
+                'required',
+                'integer',
+                Rule::exists('ecc_storage_categories', 'id')->whereNull('deleted_at'),
+            ],
+            'description'  => 'nullable|string',
+            'icon'         => 'nullable|string|max:100',
+            'stackable'    => 'sometimes|boolean',
+            'max_quantity'  => 'nullable|integer|min:1',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/StoreLabelTokenRequest.php
+++ b/v3/app/Http/Requests/StoreLabelTokenRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a request to create a new label token.
+ */
+class StoreLabelTokenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'item_type_id' => [
+                'required',
+                'integer',
+                Rule::exists('ecc_storage_item_types', 'id')->whereNull('deleted_at'),
+            ],
+            'quantity'        => 'required|integer|min:1',
+            'note'           => 'nullable|string|max:255',
+            'source'         => 'required|string|max:50',
+            'source_char_id' => 'nullable|integer',
+            'created_by'     => 'required|integer',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/TransferRequest.php
+++ b/v3/app/Http/Requests/TransferRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a request to transfer items between two characters.
+ */
+class TransferRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'source_char_id'  => 'required|integer',
+            'target_char_id'  => 'required|integer|different:source_char_id',
+            'item_type_id'    => [
+                'required',
+                'integer',
+                Rule::exists('ecc_storage_item_types', 'id')->whereNull('deleted_at'),
+            ],
+            'quantity'        => 'required|integer|min:1',
+            'brokered'        => 'sometimes|boolean',
+            'actor_joomla_id' => 'required|integer',
+            'note'           => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/UpdateCategoryRequest.php
+++ b/v3/app/Http/Requests/UpdateCategoryRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a request to update an existing storage category.
+ */
+class UpdateCategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:100',
+                Rule::unique('ecc_storage_categories', 'name')
+                    ->ignore($this->route('category')),
+            ],
+        ];
+    }
+}

--- a/v3/app/Http/Requests/UpdateItemTypeRequest.php
+++ b/v3/app/Http/Requests/UpdateItemTypeRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a request to update an existing storage item type.
+ */
+class UpdateItemTypeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:100',
+                Rule::unique('ecc_storage_item_types', 'name')
+                    ->ignore($this->route('item_type')),
+            ],
+            'category_id' => [
+                'required',
+                'integer',
+                Rule::exists('ecc_storage_categories', 'id')->whereNull('deleted_at'),
+            ],
+            'description'  => 'nullable|string',
+            'icon'         => 'nullable|string|max:100',
+            'stackable'    => 'sometimes|boolean',
+            'max_quantity'  => 'nullable|integer|min:1',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/UpdateSettingRequest.php
+++ b/v3/app/Http/Requests/UpdateSettingRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates a request to update a storage setting.
+ */
+class UpdateSettingRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'key'   => 'required|string|in:transfers_enabled',
+            'value' => 'required|string',
+        ];
+    }
+}

--- a/v3/app/Http/Resources/StorageCategoryResource.php
+++ b/v3/app/Http/Resources/StorageCategoryResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * API resource for serializing a storage category.
+ */
+class StorageCategoryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'         => $this->id,
+            'name'       => $this->name,
+            'created_at' => $this->created_at,
+            'created_by' => $this->created_by,
+            'deleted_at' => $this->deleted_at,
+            'is_system'  => $this->is_system,
+        ];
+    }
+}

--- a/v3/app/Http/Resources/StorageInventoryResource.php
+++ b/v3/app/Http/Resources/StorageInventoryResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * API resource for serializing a storage inventory row.
+ */
+class StorageInventoryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'           => $this->id,
+            'character_id' => $this->character_id,
+            'item_type_id' => $this->item_type_id,
+            'quantity'      => $this->quantity,
+            'updated_at'   => $this->updated_at,
+            'item_type'    => new StorageItemTypeResource($this->whenLoaded('itemType')),
+        ];
+    }
+}

--- a/v3/app/Http/Resources/StorageItemTypeResource.php
+++ b/v3/app/Http/Resources/StorageItemTypeResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * API resource for serializing a storage item type.
+ */
+class StorageItemTypeResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'            => $this->id,
+            'name'          => $this->name,
+            'description'   => $this->description,
+            'icon'          => $this->icon,
+            'category_id'   => $this->category_id,
+            'stackable'     => $this->stackable,
+            'max_quantity'   => $this->max_quantity,
+            'is_system'     => $this->is_system,
+            'created_at'    => $this->created_at,
+            'created_by'    => $this->created_by,
+            'updated_at'    => $this->updated_at,
+            'deleted_at'    => $this->deleted_at,
+            'category_name' => $this->whenLoaded('category', fn () => $this->category->name),
+        ];
+    }
+}

--- a/v3/app/Http/Resources/StorageLabelTokenResource.php
+++ b/v3/app/Http/Resources/StorageLabelTokenResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * API resource for serializing a storage label token.
+ */
+class StorageLabelTokenResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'              => $this->id,
+            'token'           => $this->token,
+            'item_type_id'    => $this->item_type_id,
+            'quantity'        => $this->quantity,
+            'note'            => $this->note,
+            'source'          => $this->source,
+            'source_char_id'  => $this->source_char_id,
+            'created_by'      => $this->created_by,
+            'created_at'      => $this->created_at,
+            'claimed_by'      => $this->claimed_by,
+            'claimed_at'      => $this->claimed_at,
+            'expires_at'      => $this->expires_at,
+        ];
+    }
+}

--- a/v3/app/Http/Resources/StorageLogResource.php
+++ b/v3/app/Http/Resources/StorageLogResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * API resource for serializing a storage log entry.
+ */
+class StorageLogResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'              => $this->id,
+            'item_type_id'    => $this->item_type_id,
+            'quantity'        => $this->quantity,
+            'source_char_id'  => $this->source_char_id,
+            'target_char_id'  => $this->target_char_id,
+            'actor_joomla_id' => $this->actor_joomla_id,
+            'action'          => $this->action,
+            'brokered'        => $this->brokered,
+            'note'            => $this->note,
+            'created_at'      => $this->created_at,
+        ];
+    }
+}

--- a/v3/app/Http/Resources/StorageSettingResource.php
+++ b/v3/app/Http/Resources/StorageSettingResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * API resource for serializing a storage setting.
+ */
+class StorageSettingResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'key_name'   => $this->key_name,
+            'value'      => $this->value,
+            'updated_at' => $this->updated_at,
+            'updated_by' => $this->updated_by,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Add 6 API Resource classes (`StorageCategoryResource`, `StorageItemTypeResource`, `StorageInventoryResource`, `StorageLogResource`, `StorageSettingResource`, `StorageLabelTokenResource`) — all timestamps as raw epoch integers
- Add 11 FormRequest classes for all write operations (categories, item types, inventory mint/adjust/bulk-mint, transfers, settings, labels)
- FK references to soft-deletable tables use `Rule::exists()->whereNull('deleted_at')`
- Mark V3-06 complete in PLAN.md

Closes #83

## Test plan
- [x] `php artisan test` — all 17 tests pass, no regressions
- [ ] Manual review: each Resource `toArray()` returns the expected fields
- [ ] Manual review: each FormRequest `rules()` matches the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)