### PR TITLE
Add InventoryService with unit tests

### DIFF
--- a/v3/app/Services/InventoryService.php
+++ b/v3/app/Services/InventoryService.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\StorageInventory;
+use App\Models\StorageItemType;
+use App\Models\StorageLog;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Encapsulates all inventory mutation logic: mint, burn, adjust, and bulk
+ * operations with transactional safety, max-quantity cap enforcement, and
+ * audit logging.
+ */
+class InventoryService
+{
+    /**
+     * Mint (add) a quantity of an item type into a character's inventory.
+     *
+     * @param int         $characterId  The character receiving the items.
+     * @param int         $itemTypeId   The item type to mint.
+     * @param int         $quantity     The quantity to add (must be positive).
+     * @param int         $actorJoomlaId The Joomla user ID performing the action.
+     * @param string|null $note         Optional audit note.
+     *
+     * @return StorageInventory The updated inventory row.
+     *
+     * @throws \DomainException If the mint would exceed max_quantity.
+     */
+    public function mint(int $characterId, int $itemTypeId, int $quantity, int $actorJoomlaId, ?string $note = null): StorageInventory
+    {
+        return DB::transaction(function () use ($characterId, $itemTypeId, $quantity, $actorJoomlaId, $note) {
+            $itemType = StorageItemType::findOrFail($itemTypeId);
+
+            $inventory = StorageInventory::where('character_id', $characterId)
+                ->where('item_type_id', $itemTypeId)
+                ->lockForUpdate()
+                ->first();
+
+            if ($inventory === null) {
+                $inventory = new StorageInventory([
+                    'character_id' => $characterId,
+                    'item_type_id' => $itemTypeId,
+                    'quantity'     => 0,
+                ]);
+            }
+
+            $newQty = $inventory->quantity + $quantity;
+
+            if ($itemType->max_quantity !== null && $newQty > $itemType->max_quantity) {
+                throw new \DomainException(
+                    "Mint would exceed max quantity of {$itemType->max_quantity} for item type {$itemTypeId}."
+                );
+            }
+
+            $inventory->quantity = $newQty;
+            $inventory->updated_at = time();
+            $inventory->save();
+
+            StorageLog::create([
+                'item_type_id'    => $itemTypeId,
+                'quantity'        => $quantity,
+                'source_char_id'  => null,
+                'target_char_id'  => $characterId,
+                'actor_joomla_id' => $actorJoomlaId,
+                'action'          => 'mint',
+                'note'            => $note,
+                'created_at'      => time(),
+            ]);
+
+            return $inventory;
+        });
+    }
+
+    /**
+     * Burn (remove) a quantity of an item type from a character's inventory.
+     *
+     * @param int         $characterId  The character losing the items.
+     * @param int         $itemTypeId   The item type to burn.
+     * @param int         $quantity     The quantity to remove (must be positive).
+     * @param int         $actorJoomlaId The Joomla user ID performing the action.
+     * @param string|null $note         Optional audit note.
+     *
+     * @return StorageInventory The updated inventory row.
+     *
+     * @throws \DomainException If the character has no inventory or insufficient quantity.
+     */
+    public function burn(int $characterId, int $itemTypeId, int $quantity, int $actorJoomlaId, ?string $note = null): StorageInventory
+    {
+        return DB::transaction(function () use ($characterId, $itemTypeId, $quantity, $actorJoomlaId, $note) {
+            $inventory = StorageInventory::where('character_id', $characterId)
+                ->where('item_type_id', $itemTypeId)
+                ->lockForUpdate()
+                ->first();
+
+            if ($inventory === null) {
+                throw new \DomainException(
+                    "No inventory found for character {$characterId} and item type {$itemTypeId}."
+                );
+            }
+
+            if ($inventory->quantity < $quantity) {
+                throw new \DomainException(
+                    "Insufficient quantity: have {$inventory->quantity}, tried to burn {$quantity}."
+                );
+            }
+
+            $inventory->quantity -= $quantity;
+            $inventory->updated_at = time();
+            $inventory->save();
+
+            StorageLog::create([
+                'item_type_id'    => $itemTypeId,
+                'quantity'        => $quantity,
+                'source_char_id'  => $characterId,
+                'target_char_id'  => null,
+                'actor_joomla_id' => $actorJoomlaId,
+                'action'          => 'burn',
+                'note'            => $note,
+                'created_at'      => time(),
+            ]);
+
+            return $inventory;
+        });
+    }
+
+    /**
+     * Adjust an existing inventory row by a positive or negative delta.
+     *
+     * @param int         $inventoryId   The inventory row ID to adjust.
+     * @param int         $delta         The signed quantity change (non-zero).
+     * @param int         $actorJoomlaId The Joomla user ID performing the action.
+     * @param string|null $note          Optional audit note.
+     *
+     * @return StorageInventory The updated inventory row.
+     *
+     * @throws \DomainException If delta is zero, inventory not found, cap exceeded, or insufficient quantity.
+     */
+    public function adjust(int $inventoryId, int $delta, int $actorJoomlaId, ?string $note = null): StorageInventory
+    {
+        if ($delta === 0) {
+            throw new \DomainException('Delta must not be zero.');
+        }
+
+        return DB::transaction(function () use ($inventoryId, $delta, $actorJoomlaId, $note) {
+            $inventory = StorageInventory::where('id', $inventoryId)
+                ->lockForUpdate()
+                ->first();
+
+            if ($inventory === null) {
+                throw new \DomainException("Inventory row {$inventoryId} not found.");
+            }
+
+            $newQty = $inventory->quantity + $delta;
+
+            if ($delta > 0) {
+                $itemType = StorageItemType::findOrFail($inventory->item_type_id);
+                if ($itemType->max_quantity !== null && $newQty > $itemType->max_quantity) {
+                    throw new \DomainException(
+                        "Adjust would exceed max quantity of {$itemType->max_quantity}."
+                    );
+                }
+            }
+
+            if ($delta < 0 && $newQty < 0) {
+                throw new \DomainException(
+                    "Insufficient quantity: have {$inventory->quantity}, tried to remove " . abs($delta) . '.'
+                );
+            }
+
+            $inventory->quantity = $newQty;
+            $inventory->updated_at = time();
+            $inventory->save();
+
+            $action = $delta > 0 ? 'mint' : 'burn';
+            $characterId = $inventory->character_id;
+
+            StorageLog::create([
+                'item_type_id'    => $inventory->item_type_id,
+                'quantity'        => abs($delta),
+                'source_char_id'  => $action === 'burn' ? $characterId : null,
+                'target_char_id'  => $action === 'mint' ? $characterId : null,
+                'actor_joomla_id' => $actorJoomlaId,
+                'action'          => $action,
+                'note'            => $note,
+                'created_at'      => time(),
+            ]);
+
+            return $inventory;
+        });
+    }
+
+    /**
+     * Mint items to multiple characters in bulk. Each mint runs in its own
+     * transaction; failures are collected rather than aborting the batch.
+     *
+     * @param int    $itemTypeId    The item type to mint.
+     * @param int    $quantity      The quantity to mint per character.
+     * @param int[]  $characterIds  Array of character IDs to receive items.
+     * @param int    $actorJoomlaId The Joomla user ID performing the action.
+     * @param string|null $note     Optional audit note.
+     *
+     * @return array{succeeded: array<int, array{character_id: int, new_quantity: int}>, failed: array<int, array{character_id: int, error: string}>}
+     */
+    public function bulk(int $itemTypeId, int $quantity, array $characterIds, int $actorJoomlaId, ?string $note = null): array
+    {
+        $succeeded = [];
+        $failed = [];
+
+        foreach ($characterIds as $characterId) {
+            try {
+                $inventory = $this->mint($characterId, $itemTypeId, $quantity, $actorJoomlaId, $note);
+                $succeeded[] = [
+                    'character_id' => $characterId,
+                    'new_quantity' => $inventory->quantity,
+                ];
+            } catch (\Throwable $e) {
+                $failed[] = [
+                    'character_id' => $characterId,
+                    'error'        => $e->getMessage(),
+                ];
+            }
+        }
+
+        return ['succeeded' => $succeeded, 'failed' => $failed];
+    }
+}

--- a/v3/bootstrap/app.php
+++ b/v3/bootstrap/app.php
@@ -16,5 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        $exceptions->renderable(function (\DomainException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        });
     })->create();

--- a/v3/tests/Unit/Services/InventoryServiceTest.php
+++ b/v3/tests/Unit/Services/InventoryServiceTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\StorageCategory;
+use App\Models\StorageInventory;
+use App\Models\StorageItemType;
+use App\Models\StorageLog;
+use App\Services\InventoryService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Unit tests for InventoryService covering mint, burn, adjust, and bulk
+ * operations including cap enforcement, transactional rollback, and audit logging.
+ */
+class InventoryServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private InventoryService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new InventoryService();
+    }
+
+    /**
+     * Create a StorageItemType (and its required category) with sensible defaults.
+     */
+    private function createItemType(array $overrides = []): StorageItemType
+    {
+        $category = StorageCategory::create([
+            'name'       => 'Test Category',
+            'created_at' => time(),
+            'created_by' => 1,
+        ]);
+
+        return StorageItemType::create(array_merge([
+            'name'         => 'Test Item',
+            'description'  => 'A test item',
+            'category_id'  => $category->id,
+            'stackable'    => true,
+            'max_quantity'  => null,
+            'is_system'    => false,
+            'created_at'   => time(),
+            'created_by'   => 1,
+            'updated_at'   => time(),
+        ], $overrides));
+    }
+
+    public function test_mint_creates_inventory_and_log(): void
+    {
+        $itemType = $this->createItemType();
+
+        $inventory = $this->service->mint(100, $itemType->id, 5, 1, 'initial grant');
+
+        $this->assertEquals(5, $inventory->quantity);
+        $this->assertEquals(100, $inventory->character_id);
+        $this->assertEquals($itemType->id, $inventory->item_type_id);
+
+        $this->assertDatabaseHas('ecc_storage_inventory', [
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 5,
+        ]);
+
+        $this->assertDatabaseHas('ecc_storage_log', [
+            'item_type_id'    => $itemType->id,
+            'quantity'        => 5,
+            'target_char_id'  => 100,
+            'source_char_id'  => null,
+            'action'          => 'mint',
+            'note'            => 'initial grant',
+        ]);
+    }
+
+    public function test_mint_increments_existing_inventory(): void
+    {
+        $itemType = $this->createItemType();
+
+        $this->service->mint(100, $itemType->id, 3, 1);
+        $inventory = $this->service->mint(100, $itemType->id, 7, 1);
+
+        $this->assertEquals(10, $inventory->quantity);
+        $this->assertCount(2, StorageLog::where('item_type_id', $itemType->id)->get());
+    }
+
+    public function test_mint_throws_when_max_quantity_exceeded(): void
+    {
+        $itemType = $this->createItemType(['max_quantity' => 10]);
+
+        $this->expectException(\DomainException::class);
+        $this->service->mint(100, $itemType->id, 11, 1);
+
+        $this->assertDatabaseMissing('ecc_storage_inventory', [
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+        ]);
+    }
+
+    public function test_mint_allows_exactly_at_max_quantity(): void
+    {
+        $itemType = $this->createItemType(['max_quantity' => 10]);
+
+        $inventory = $this->service->mint(100, $itemType->id, 10, 1);
+
+        $this->assertEquals(10, $inventory->quantity);
+    }
+
+    public function test_mint_with_null_max_quantity_has_no_cap(): void
+    {
+        $itemType = $this->createItemType(['max_quantity' => null]);
+
+        $inventory = $this->service->mint(100, $itemType->id, 999999, 1);
+
+        $this->assertEquals(999999, $inventory->quantity);
+    }
+
+    public function test_burn_decrements_and_creates_log(): void
+    {
+        $itemType = $this->createItemType();
+        $this->service->mint(100, $itemType->id, 10, 1);
+
+        $inventory = $this->service->burn(100, $itemType->id, 3, 1, 'consumed');
+
+        $this->assertEquals(7, $inventory->quantity);
+
+        $this->assertDatabaseHas('ecc_storage_log', [
+            'item_type_id'    => $itemType->id,
+            'quantity'        => 3,
+            'source_char_id'  => 100,
+            'target_char_id'  => null,
+            'action'          => 'burn',
+            'note'            => 'consumed',
+        ]);
+    }
+
+    public function test_burn_throws_on_insufficient_quantity(): void
+    {
+        $itemType = $this->createItemType();
+        $this->service->mint(100, $itemType->id, 5, 1);
+
+        $this->expectException(\DomainException::class);
+        $this->service->burn(100, $itemType->id, 10, 1);
+    }
+
+    public function test_burn_throws_on_nonexistent_inventory(): void
+    {
+        $itemType = $this->createItemType();
+
+        $this->expectException(\DomainException::class);
+        $this->service->burn(100, $itemType->id, 1, 1);
+    }
+
+    public function test_adjust_positive_with_cap_check(): void
+    {
+        $itemType = $this->createItemType(['max_quantity' => 20]);
+        $inventory = $this->service->mint(100, $itemType->id, 15, 1);
+
+        // Adjust up to exactly the cap — should succeed
+        $adjusted = $this->service->adjust($inventory->id, 5, 1, 'top up');
+        $this->assertEquals(20, $adjusted->quantity);
+
+        // Adjust over the cap — should throw
+        $this->expectException(\DomainException::class);
+        $this->service->adjust($inventory->id, 1, 1);
+    }
+
+    public function test_adjust_negative_with_sufficiency_check(): void
+    {
+        $itemType = $this->createItemType();
+        $inventory = $this->service->mint(100, $itemType->id, 10, 1);
+
+        // Partial removal — should succeed
+        $adjusted = $this->service->adjust($inventory->id, -4, 1);
+        $this->assertEquals(6, $adjusted->quantity);
+
+        // Overdraw — should throw
+        $this->expectException(\DomainException::class);
+        $this->service->adjust($inventory->id, -7, 1);
+    }
+
+    public function test_bulk_all_succeed(): void
+    {
+        $itemType = $this->createItemType();
+
+        $result = $this->service->bulk($itemType->id, 5, [101, 102, 103], 1, 'bulk grant');
+
+        $this->assertCount(3, $result['succeeded']);
+        $this->assertCount(0, $result['failed']);
+
+        foreach ($result['succeeded'] as $entry) {
+            $this->assertEquals(5, $entry['new_quantity']);
+        }
+    }
+
+    public function test_bulk_partial_failure(): void
+    {
+        $itemType = $this->createItemType(['max_quantity' => 5]);
+
+        // Pre-fill one character to the cap
+        $this->service->mint(101, $itemType->id, 5, 1);
+
+        $result = $this->service->bulk($itemType->id, 3, [101, 102, 103], 1);
+
+        // 101 should fail (already at cap), 102 and 103 should succeed
+        $this->assertCount(2, $result['succeeded']);
+        $this->assertCount(1, $result['failed']);
+        $this->assertEquals(101, $result['failed'][0]['character_id']);
+    }
+
+    public function test_mint_transaction_rolls_back_on_cap_exceeded(): void
+    {
+        $itemType = $this->createItemType(['max_quantity' => 5]);
+
+        try {
+            $this->service->mint(100, $itemType->id, 10, 1);
+        } catch (\DomainException) {
+            // expected
+        }
+
+        $this->assertDatabaseMissing('ecc_storage_inventory', [
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+        ]);
+
+        $this->assertDatabaseMissing('ecc_storage_log', [
+            'item_type_id'   => $itemType->id,
+            'target_char_id' => 100,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Added `DomainException` → 422 JSON rendering in `bootstrap/app.php`
- Added `InventoryService` with `mint()`, `burn()`, `adjust()`, and `bulk()` methods — transactional, with `lockForUpdate()` and max_quantity cap enforcement
- Added 13 unit tests covering all operations, cap checks, and transaction rollback

Closes #84

## Test plan
- [x] All 13 InventoryServiceTest tests pass
- [x] Full test suite passes (30 tests, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)