### PR TITLE
Add all v3/storage controllers, routes, and feature tests (V3-10–V3-14)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -427,21 +427,21 @@ ORDER BY created_at DESC LIMIT 50 OFFSET 0
 ### Step 5 — Services ([orthanc#101](https://github.com/eosfrontier/orthanc/issues/101))
 - [x] V3-07 ([orthanc#84](https://github.com/eosfrontier/orthanc/issues/84)): `InventoryService` — mint/burn/adjust/bulk inside `DB::transaction()`; `max_quantity` cap (422) + unit tests
 - [x] V3-08 ([orthanc#85](https://github.com/eosfrontier/orthanc/issues/85)): `TransferService` — brokered logic; `transfers_enabled` gate (423); receiver cap check + unit tests
-- [ ] V3-09 ([orthanc#86](https://github.com/eosfrontier/orthanc/issues/86)): `LabelService` — token creation, claim flow + unit tests
+- [x] V3-09 ([orthanc#86](https://github.com/eosfrontier/orthanc/issues/86)): `LabelService` — token creation, claim flow + unit tests
 
 ### Step 6 — Controllers + routes ([orthanc#102](https://github.com/eosfrontier/orthanc/issues/102))
-- [ ] V3-10 ([orthanc#87](https://github.com/eosfrontier/orthanc/issues/87)): `CategoryController` + `ItemTypeController` + apiResource routes + feature tests
-- [ ] V3-11 ([orthanc#88](https://github.com/eosfrontier/orthanc/issues/88)): `InventoryController` + feature tests (bulk, cap enforcement, partial success 207)
-- [ ] V3-12 ([orthanc#89](https://github.com/eosfrontier/orthanc/issues/89)): `TransferController` + feature tests (brokered, transfers locked 423, cap exceeded)
-- [ ] V3-13 ([orthanc#90](https://github.com/eosfrontier/orthanc/issues/90)): `LogController` + UNION ALL query (verify index hits with EXPLAIN) + feature tests
-- [ ] V3-14 ([orthanc#91](https://github.com/eosfrontier/orthanc/issues/91)): `SettingsController` + feature tests
+- [x] V3-10 ([orthanc#87](https://github.com/eosfrontier/orthanc/issues/87)): `CategoryController` + `ItemTypeController` + apiResource routes + feature tests
+- [x] V3-11 ([orthanc#88](https://github.com/eosfrontier/orthanc/issues/88)): `InventoryController` + feature tests (bulk, cap enforcement, partial success 207)
+- [x] V3-12 ([orthanc#89](https://github.com/eosfrontier/orthanc/issues/89)): `TransferController` + feature tests (brokered, transfers locked 423, cap exceeded)
+- [x] V3-13 ([orthanc#90](https://github.com/eosfrontier/orthanc/issues/90)): `LogController` + UNION ALL query (verify index hits with EXPLAIN) + feature tests
+- [x] V3-14 ([orthanc#91](https://github.com/eosfrontier/orthanc/issues/91)): `SettingsController` + feature tests
 - [ ] V3-15 ([orthanc#92](https://github.com/eosfrontier/orthanc/issues/92)): Apache/vhost config: serve `orthanc/v3/public/` alongside v2; confirm v2 joomla/chars endpoints still resolve
 - Smoke-test all endpoints with curl using an issued Sanctum token
 
 ### Step 7 — Label Printing ([orthanc#103](https://github.com/eosfrontier/orthanc/issues/103))
 - [ ] LBL-01 ([orthanc#93](https://github.com/eosfrontier/orthanc/issues/93)): `ecc_storage_label_tokens` migration (in `v3/database/migrations/`) + rollback SQL
-- [ ] LBL-02 ([orthanc#94](https://github.com/eosfrontier/orthanc/issues/94)): `LabelController` + `LabelService` (already scaffolded in Step 5) + feature tests
-- [ ] LBL-03 ([orthanc#95](https://github.com/eosfrontier/orthanc/issues/95)): Label routes in `routes/api.php`: POST `/v3/storage/labels`, GET `/v3/storage/labels`, POST `/v3/storage/labels/claim`
+- [x] LBL-02 ([orthanc#94](https://github.com/eosfrontier/orthanc/issues/94)): `LabelController` + `LabelService` (already scaffolded in Step 5) + feature tests
+- [x] LBL-03 ([orthanc#95](https://github.com/eosfrontier/orthanc/issues/95)): Label routes in `routes/api.php`: POST `/v3/storage/labels`, GET `/v3/storage/labels`, POST `/v3/storage/labels/claim`
 
 ---
 

--- a/v3/app/Enums/LogAction.php
+++ b/v3/app/Enums/LogAction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Actions recorded in the storage audit log.
+ *
+ * Each case maps to a distinct inventory operation that produces a log entry.
+ */
+enum LogAction: string
+{
+    case Mint = 'mint';
+    case Burn = 'burn';
+    case Transfer = 'transfer';
+    case BrokerFee = 'broker_fee';
+    case LabelClaim = 'label_claim';
+    case LabelBurn = 'label_burn';
+}

--- a/v3/app/Http/Controllers/Api/CategoryController.php
+++ b/v3/app/Http/Controllers/Api/CategoryController.php
@@ -47,7 +47,7 @@ class CategoryController extends Controller
         $category = StorageCategory::create([
             'name'       => $request->validated('name'),
             'created_at' => time(),
-            'created_by' => $request->input('actor_id', 0),
+            'created_by' => $request->validated('actor_id'),
         ]);
 
         return (new StorageCategoryResource($category))

--- a/v3/app/Http/Controllers/Api/CategoryController.php
+++ b/v3/app/Http/Controllers/Api/CategoryController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreCategoryRequest;
+use App\Http\Requests\UpdateCategoryRequest;
+use App\Http\Resources\StorageCategoryResource;
+use App\Models\StorageCategory;
+use App\Models\StorageItemType;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * Handles CRUD operations for storage categories.
+ *
+ * Categories group item types into logical sets (e.g. "Currency", "Weapons").
+ * System categories (is_system = 1) are protected from update and deletion.
+ */
+class CategoryController extends Controller
+{
+    /**
+     * List all active categories.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $categories = StorageCategory::active()->get();
+
+        return StorageCategoryResource::collection($categories);
+    }
+
+    /**
+     * Show a single active category by ID.
+     */
+    public function show(int $id): StorageCategoryResource
+    {
+        $category = StorageCategory::active()->findOrFail($id);
+
+        return new StorageCategoryResource($category);
+    }
+
+    /**
+     * Create a new category.
+     */
+    public function store(StoreCategoryRequest $request): JsonResponse
+    {
+        $category = StorageCategory::create([
+            'name'       => $request->validated('name'),
+            'created_at' => time(),
+            'created_by' => $request->input('actor_id', 0),
+        ]);
+
+        return (new StorageCategoryResource($category))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Update an existing category. System categories cannot be renamed.
+     */
+    public function update(UpdateCategoryRequest $request, int $id): StorageCategoryResource
+    {
+        $category = StorageCategory::active()->findOrFail($id);
+
+        if ($category->is_system) {
+            abort(403, 'System categories cannot be modified.');
+        }
+
+        $category->update([
+            'name' => $request->validated('name'),
+        ]);
+
+        return new StorageCategoryResource($category);
+    }
+
+    /**
+     * Soft-delete a category. Rejected if system or has active item types.
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        $category = StorageCategory::active()->findOrFail($id);
+
+        if ($category->is_system) {
+            abort(403, 'System categories cannot be deleted.');
+        }
+
+        if (StorageItemType::active()->where('category_id', $id)->exists()) {
+            abort(409, 'Cannot delete category with active item types.');
+        }
+
+        $category->update(['deleted_at' => time()]);
+
+        return response()->json(null, 204);
+    }
+}

--- a/v3/app/Http/Controllers/Api/InventoryController.php
+++ b/v3/app/Http/Controllers/Api/InventoryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AdjustInventoryRequest;
 use App\Http\Requests\BulkMintInventoryRequest;
+use App\Http\Requests\BurnInventoryRequest;
 use App\Http\Requests\MintInventoryRequest;
 use App\Http\Resources\StorageInventoryResource;
 use App\Models\StorageInventory;
@@ -79,22 +80,16 @@ class InventoryController extends Controller
     /**
      * Burn (remove) items from a character's inventory.
      */
-    public function destroy(Request $request, int $id): JsonResponse
+    public function destroy(BurnInventoryRequest $request, int $id): JsonResponse
     {
         $inventoryRow = StorageInventory::findOrFail($id);
-
-        $request->validate([
-            'quantity' => 'required|integer|min:1',
-            'actor_id' => 'required|integer',
-            'note'     => 'nullable|string|max:255',
-        ]);
 
         $inventory = $this->inventoryService->burn(
             $inventoryRow->character_id,
             $inventoryRow->item_type_id,
-            (int) $request->input('quantity'),
-            (int) $request->input('actor_id'),
-            $request->input('note'),
+            $request->validated('quantity'),
+            $request->validated('actor_id'),
+            $request->validated('note'),
         );
 
         $inventory->load('itemType.category');

--- a/v3/app/Http/Controllers/Api/InventoryController.php
+++ b/v3/app/Http/Controllers/Api/InventoryController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AdjustInventoryRequest;
+use App\Http\Requests\BulkMintInventoryRequest;
+use App\Http\Requests\MintInventoryRequest;
+use App\Http\Resources\StorageInventoryResource;
+use App\Models\StorageInventory;
+use App\Services\InventoryService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * Handles inventory operations: listing, minting, adjusting, burning, and bulk minting.
+ */
+class InventoryController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct(
+        private readonly InventoryService $inventoryService,
+    ) {}
+
+    /**
+     * List inventory for a character, eager-loading item type and category.
+     */
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $request->validate(['char_id' => 'required|integer']);
+
+        $inventory = StorageInventory::where('character_id', $request->query('char_id'))
+            ->with('itemType.category')
+            ->get();
+
+        return StorageInventoryResource::collection($inventory);
+    }
+
+    /**
+     * Mint items into a character's inventory.
+     */
+    public function store(MintInventoryRequest $request): JsonResponse
+    {
+        $inventory = $this->inventoryService->mint(
+            $request->validated('character_id'),
+            $request->validated('item_type_id'),
+            $request->validated('quantity'),
+            $request->validated('actor_id'),
+            $request->validated('note'),
+        );
+
+        $inventory->load('itemType.category');
+
+        return (new StorageInventoryResource($inventory))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Adjust an inventory row by a signed delta.
+     */
+    public function adjust(AdjustInventoryRequest $request, int $id): StorageInventoryResource
+    {
+        $inventory = $this->inventoryService->adjust(
+            $id,
+            $request->validated('quantity'),
+            $request->validated('actor_id'),
+            $request->validated('note'),
+        );
+
+        $inventory->load('itemType.category');
+
+        return new StorageInventoryResource($inventory);
+    }
+
+    /**
+     * Burn (remove) items from a character's inventory.
+     */
+    public function destroy(Request $request, int $id): JsonResponse
+    {
+        $inventoryRow = StorageInventory::findOrFail($id);
+
+        $request->validate([
+            'quantity' => 'required|integer|min:1',
+            'actor_id' => 'required|integer',
+            'note'     => 'nullable|string|max:255',
+        ]);
+
+        $inventory = $this->inventoryService->burn(
+            $inventoryRow->character_id,
+            $inventoryRow->item_type_id,
+            (int) $request->input('quantity'),
+            (int) $request->input('actor_id'),
+            $request->input('note'),
+        );
+
+        $inventory->load('itemType.category');
+
+        return (new StorageInventoryResource($inventory))
+            ->response()
+            ->setStatusCode(200);
+    }
+
+    /**
+     * Bulk mint items to multiple characters. Returns 201/207/422 based on results.
+     */
+    public function bulk(BulkMintInventoryRequest $request): JsonResponse
+    {
+        $result = $this->inventoryService->bulk(
+            $request->validated('item_type_id'),
+            $request->validated('quantity'),
+            $request->validated('character_ids'),
+            $request->validated('actor_id'),
+            $request->validated('note'),
+        );
+
+        $totalAttempted = count($result['succeeded']) + count($result['failed']);
+        $totalSucceeded = count($result['succeeded']);
+        $totalFailed = count($result['failed']);
+
+        $response = [
+            'total_attempted' => $totalAttempted,
+            'total_succeeded' => $totalSucceeded,
+            'total_failed'    => $totalFailed,
+            'succeeded'       => array_map(fn ($s) => [
+                'char_id'      => $s['character_id'],
+                'new_quantity' => $s['new_quantity'],
+            ], $result['succeeded']),
+            'failed' => array_map(fn ($f) => [
+                'char_id' => $f['character_id'],
+                'error'   => $f['error'],
+            ], $result['failed']),
+        ];
+
+        if ($totalFailed === 0) {
+            $status = 201;
+        } elseif ($totalSucceeded > 0) {
+            $status = 207;
+        } else {
+            $status = 422;
+        }
+
+        return response()->json($response, $status);
+    }
+}

--- a/v3/app/Http/Controllers/Api/ItemTypeController.php
+++ b/v3/app/Http/Controllers/Api/ItemTypeController.php
@@ -44,10 +44,10 @@ class ItemTypeController extends Controller
     public function store(StoreItemTypeRequest $request): JsonResponse
     {
         $itemType = StorageItemType::create(array_merge(
-            $request->validated(),
+            $request->safe()->except(['actor_id']),
             [
                 'created_at' => time(),
-                'created_by' => $request->input('actor_id', 0),
+                'created_by' => $request->validated('actor_id'),
                 'updated_at' => time(),
             ]
         ));

--- a/v3/app/Http/Controllers/Api/ItemTypeController.php
+++ b/v3/app/Http/Controllers/Api/ItemTypeController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreItemTypeRequest;
+use App\Http\Requests\UpdateItemTypeRequest;
+use App\Http\Resources\StorageItemTypeResource;
+use App\Models\StorageItemType;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * Handles CRUD operations for storage item types.
+ *
+ * Item types define the properties of storable items (stackable, max_quantity, etc.).
+ * System item types (is_system = 1) are protected from update and deletion.
+ */
+class ItemTypeController extends Controller
+{
+    /**
+     * List all active item types with their category eager-loaded.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $itemTypes = StorageItemType::active()->with('category')->get();
+
+        return StorageItemTypeResource::collection($itemTypes);
+    }
+
+    /**
+     * Show a single active item type by ID with its category.
+     */
+    public function show(int $id): StorageItemTypeResource
+    {
+        $itemType = StorageItemType::active()->with('category')->findOrFail($id);
+
+        return new StorageItemTypeResource($itemType);
+    }
+
+    /**
+     * Create a new item type.
+     */
+    public function store(StoreItemTypeRequest $request): JsonResponse
+    {
+        $itemType = StorageItemType::create(array_merge(
+            $request->validated(),
+            [
+                'created_at' => time(),
+                'created_by' => $request->input('actor_id', 0),
+                'updated_at' => time(),
+            ]
+        ));
+
+        $itemType->load('category');
+
+        return (new StorageItemTypeResource($itemType))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Update an existing item type. System item types cannot be modified.
+     */
+    public function update(UpdateItemTypeRequest $request, int $id): StorageItemTypeResource
+    {
+        $itemType = StorageItemType::active()->findOrFail($id);
+
+        if ($itemType->is_system) {
+            abort(403, 'System item types cannot be modified.');
+        }
+
+        $itemType->update(array_merge(
+            $request->validated(),
+            ['updated_at' => time()]
+        ));
+
+        $itemType->load('category');
+
+        return new StorageItemTypeResource($itemType);
+    }
+
+    /**
+     * Soft-delete an item type. System item types cannot be deleted.
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        $itemType = StorageItemType::active()->findOrFail($id);
+
+        if ($itemType->is_system) {
+            abort(403, 'System item types cannot be deleted.');
+        }
+
+        $itemType->update(['deleted_at' => time()]);
+
+        return response()->json(null, 204);
+    }
+}

--- a/v3/app/Http/Controllers/Api/LabelController.php
+++ b/v3/app/Http/Controllers/Api/LabelController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ClaimLabelTokenRequest;
+use App\Http\Requests\StoreLabelTokenRequest;
+use App\Http\Resources\StorageLabelTokenResource;
+use App\Services\LabelService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * Handles label token operations: listing, creation, and claiming.
+ *
+ * Label tokens are single-use physical tokens that can be claimed by a
+ * character to receive items into their inventory.
+ */
+class LabelController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct(
+        private readonly LabelService $labelService,
+    ) {}
+
+    /**
+     * List label tokens. Supports `?token=<uuid>` for single lookup
+     * or `?unclaimed=1` for admin listing of all unclaimed tokens.
+     */
+    public function index(Request $request): StorageLabelTokenResource|AnonymousResourceCollection
+    {
+        if ($request->has('token')) {
+            $token = $this->labelService->getByToken($request->query('token'));
+
+            if ($token === null) {
+                abort(404, 'Label token not found.');
+            }
+
+            return new StorageLabelTokenResource($token);
+        }
+
+        if ($request->boolean('unclaimed')) {
+            return StorageLabelTokenResource::collection($this->labelService->getUnclaimed());
+        }
+
+        return StorageLabelTokenResource::collection($this->labelService->getUnclaimed());
+    }
+
+    /**
+     * Create a new label token (mint or burn source).
+     */
+    public function store(StoreLabelTokenRequest $request): JsonResponse
+    {
+        $token = $this->labelService->create(
+            $request->validated(),
+            $request->validated('actor_id'),
+        );
+
+        return (new StorageLabelTokenResource($token))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Claim a label token, minting its items into a character's inventory.
+     */
+    public function claim(ClaimLabelTokenRequest $request): JsonResponse
+    {
+        $token = $this->labelService->claim(
+            $request->validated('token'),
+            $request->validated('character_id'),
+            $request->validated('actor_id'),
+        );
+
+        return (new StorageLabelTokenResource($token))
+            ->response()
+            ->setStatusCode(200);
+    }
+}

--- a/v3/app/Http/Controllers/Api/LabelController.php
+++ b/v3/app/Http/Controllers/Api/LabelController.php
@@ -46,7 +46,7 @@ class LabelController extends Controller
             return StorageLabelTokenResource::collection($this->labelService->getUnclaimed());
         }
 
-        return StorageLabelTokenResource::collection($this->labelService->getUnclaimed());
+        return StorageLabelTokenResource::collection($this->labelService->getAll());
     }
 
     /**

--- a/v3/app/Http/Controllers/Api/LogController.php
+++ b/v3/app/Http/Controllers/Api/LogController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\StorageLogResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Provides read access to the storage audit log with UNION ALL optimised
+ * character queries and manual pagination.
+ */
+class LogController extends Controller
+{
+    /**
+     * List log entries with optional filters and manual pagination.
+     *
+     * Supports `char_id`, `item_type_id`, `include_brokered`, `per_page`, and `page` params.
+     * Character queries use UNION ALL on source/target indexes for performance.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $request->validate([
+            'char_id'           => 'sometimes|integer',
+            'item_type_id'      => 'sometimes|integer',
+            'include_brokered'  => 'sometimes|boolean',
+            'per_page'          => 'sometimes|integer|min:1|max:200',
+            'page'              => 'sometimes|integer|min:1',
+        ]);
+
+        $perPage = min((int) $request->query('per_page', 50), 200);
+        $page = max((int) $request->query('page', 1), 1);
+        $offset = ($page - 1) * $perPage;
+        $includeBrokered = (bool) $request->query('include_brokered', false);
+        $charId = $request->query('char_id');
+        $itemTypeId = $request->query('item_type_id');
+
+        if ($charId !== null) {
+            $query = $this->buildCharQuery((int) $charId, $includeBrokered, $itemTypeId ? (int) $itemTypeId : null);
+        } else {
+            $query = DB::table('ecc_storage_log');
+
+            if (! $includeBrokered) {
+                $query->where('brokered', 0);
+            }
+
+            if ($itemTypeId !== null) {
+                $query->where('item_type_id', (int) $itemTypeId);
+            }
+        }
+
+        // Fetch one extra to determine has_more
+        $rows = $query
+            ->orderByDesc('created_at')
+            ->offset($offset)
+            ->limit($perPage + 1)
+            ->get();
+
+        $hasMore = $rows->count() > $perPage;
+        $rows = $rows->take($perPage);
+
+        return response()->json([
+            'data'     => StorageLogResource::collection($rows),
+            'page'     => $page,
+            'per_page' => $perPage,
+            'has_more' => $hasMore,
+        ]);
+    }
+
+    /**
+     * Build a UNION ALL query for character-filtered log entries.
+     *
+     * Uses two sub-queries targeting the source_char_id and target_char_id
+     * indexes respectively, then wraps in an outer query for ordering/pagination.
+     *
+     * @param int      $charId          The character ID to filter on.
+     * @param bool     $includeBrokered Whether to include brokered rows.
+     * @param int|null $itemTypeId      Optional item type filter.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    private function buildCharQuery(int $charId, bool $includeBrokered, ?int $itemTypeId): \Illuminate\Database\Query\Builder
+    {
+        $sourceQuery = DB::table('ecc_storage_log')
+            ->where('source_char_id', $charId);
+
+        $targetQuery = DB::table('ecc_storage_log')
+            ->where('target_char_id', $charId);
+
+        if (! $includeBrokered) {
+            $sourceQuery->where('brokered', 0);
+            $targetQuery->where('brokered', 0);
+        }
+
+        if ($itemTypeId !== null) {
+            $sourceQuery->where('item_type_id', $itemTypeId);
+            $targetQuery->where('item_type_id', $itemTypeId);
+        }
+
+        return DB::query()->fromSub(
+            $sourceQuery->unionAll($targetQuery),
+            'log'
+        );
+    }
+}

--- a/v3/app/Http/Controllers/Api/SettingsController.php
+++ b/v3/app/Http/Controllers/Api/SettingsController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateSettingRequest;
+use App\Http\Resources\StorageSettingResource;
+use App\Models\StorageSetting;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * Provides read and admin-write access to storage system settings.
+ */
+class SettingsController extends Controller
+{
+    /**
+     * List all settings.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        return StorageSettingResource::collection(StorageSetting::all());
+    }
+
+    /**
+     * Update a single setting by key. Unknown keys are rejected by the FormRequest.
+     */
+    public function update(UpdateSettingRequest $request): StorageSettingResource
+    {
+        $setting = StorageSetting::where('key_name', $request->validated('key'))->firstOrFail();
+
+        $setting->update([
+            'value'      => $request->validated('value'),
+            'updated_at' => time(),
+            'updated_by' => $request->input('actor_id', 0),
+        ]);
+
+        return new StorageSettingResource($setting);
+    }
+}

--- a/v3/app/Http/Controllers/Api/SettingsController.php
+++ b/v3/app/Http/Controllers/Api/SettingsController.php
@@ -31,7 +31,7 @@ class SettingsController extends Controller
         $setting->update([
             'value'      => $request->validated('value'),
             'updated_at' => time(),
-            'updated_by' => $request->input('actor_id', 0),
+            'updated_by' => $request->validated('actor_id'),
         ]);
 
         return new StorageSettingResource($setting);

--- a/v3/app/Http/Controllers/Api/TransferController.php
+++ b/v3/app/Http/Controllers/Api/TransferController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\TransferRequest;
+use App\Http\Resources\StorageInventoryResource;
+use App\Services\TransferService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Handles item transfers between characters, including brokered transfers.
+ *
+ * Delegates entirely to TransferService; exceptions are handled globally
+ * in bootstrap/app.php (DomainException → 422, TransfersLockedException → 423).
+ */
+class TransferController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct(
+        private readonly TransferService $transferService,
+    ) {}
+
+    /**
+     * Transfer items from one character to another.
+     */
+    public function store(TransferRequest $request): JsonResponse
+    {
+        $result = $this->transferService->transfer(
+            $request->validated('source_char_id'),
+            $request->validated('target_char_id'),
+            $request->validated('item_type_id'),
+            $request->validated('quantity'),
+            $request->validated('actor_id'),
+            (bool) $request->validated('brokered', false),
+            $request->validated('note'),
+        );
+
+        return response()->json([
+            'data' => [
+                'source' => new StorageInventoryResource($result['source']),
+                'target' => new StorageInventoryResource($result['target']),
+            ],
+        ], 201);
+    }
+}

--- a/v3/app/Http/Requests/BulkMintInventoryRequest.php
+++ b/v3/app/Http/Requests/BulkMintInventoryRequest.php
@@ -32,8 +32,8 @@ class BulkMintInventoryRequest extends FormRequest
                 Rule::exists('ecc_storage_item_types', 'id')->whereNull('deleted_at'),
             ],
             'quantity'        => 'required|integer|min:1',
-            'character_ids'   => 'required|array|max:200',
-            'character_ids.*' => 'integer',
+            'character_ids'   => 'required|array|min:1|max:200',
+            'character_ids.*' => 'integer|min:1',
             'actor_id'        => 'required|integer',
             'note'           => 'nullable|string|max:255',
         ];

--- a/v3/app/Http/Requests/BurnInventoryRequest.php
+++ b/v3/app/Http/Requests/BurnInventoryRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates a request to burn (remove) items from a character's inventory.
+ */
+class BurnInventoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'quantity' => 'required|integer|min:1',
+            'actor_id' => 'required|integer',
+            'note'     => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/v3/app/Http/Requests/ClaimLabelTokenRequest.php
+++ b/v3/app/Http/Requests/ClaimLabelTokenRequest.php
@@ -25,7 +25,7 @@ class ClaimLabelTokenRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'token'           => 'required|string|size:36',
+            'token'           => 'required|string|uuid',
             'character_id'    => 'required|integer',
             'actor_id'        => 'required|integer',
         ];

--- a/v3/app/Http/Requests/StoreCategoryRequest.php
+++ b/v3/app/Http/Requests/StoreCategoryRequest.php
@@ -25,7 +25,8 @@ class StoreCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:100|unique:ecc_storage_categories,name',
+            'name'     => 'required|string|max:100|unique:ecc_storage_categories,name',
+            'actor_id' => 'required|integer',
         ];
     }
 }

--- a/v3/app/Http/Requests/StoreItemTypeRequest.php
+++ b/v3/app/Http/Requests/StoreItemTypeRequest.php
@@ -32,7 +32,7 @@ class StoreItemTypeRequest extends FormRequest
                 'integer',
                 Rule::exists('ecc_storage_categories', 'id')->whereNull('deleted_at'),
             ],
-            'description'  => 'nullable|string',
+            'description'  => 'nullable|string|max:1000',
             'icon'         => 'nullable|string|max:100',
             'stackable'    => 'sometimes|boolean',
             'max_quantity'  => 'nullable|integer|min:1',

--- a/v3/app/Http/Requests/StoreItemTypeRequest.php
+++ b/v3/app/Http/Requests/StoreItemTypeRequest.php
@@ -36,6 +36,7 @@ class StoreItemTypeRequest extends FormRequest
             'icon'         => 'nullable|string|max:100',
             'stackable'    => 'sometimes|boolean',
             'max_quantity'  => 'nullable|integer|min:1',
+            'actor_id'      => 'required|integer',
         ];
     }
 }

--- a/v3/app/Http/Requests/StoreLabelTokenRequest.php
+++ b/v3/app/Http/Requests/StoreLabelTokenRequest.php
@@ -38,6 +38,8 @@ class StoreLabelTokenRequest extends FormRequest
             'note'               => 'nullable|string|max:255',
             'source'             => ['required', Rule::in(LabelTokenSource::cases())],
             'source_char_id'     => 'nullable|integer',
+            'actor_id'           => 'required|integer',
+            'expires_at'         => 'nullable|integer',
         ];
     }
 }

--- a/v3/app/Http/Requests/StoreLabelTokenRequest.php
+++ b/v3/app/Http/Requests/StoreLabelTokenRequest.php
@@ -27,7 +27,7 @@ class StoreLabelTokenRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'items'                => 'required|array|min:1',
+            'items'                => 'required|array|min:1|max:50',
             'items.*.item_type_id' => [
                 'required',
                 'integer',
@@ -37,9 +37,9 @@ class StoreLabelTokenRequest extends FormRequest
             'items.*.quantity'    => 'required|integer|min:1',
             'note'               => 'nullable|string|max:255',
             'source'             => ['required', Rule::in(LabelTokenSource::cases())],
-            'source_char_id'     => 'nullable|integer',
+            'source_char_id'     => 'nullable|required_if:source,burn|integer',
             'actor_id'           => 'required|integer',
-            'expires_at'         => 'nullable|integer',
+            'expires_at'         => 'nullable|integer|min:0',
         ];
     }
 }

--- a/v3/app/Http/Requests/UpdateItemTypeRequest.php
+++ b/v3/app/Http/Requests/UpdateItemTypeRequest.php
@@ -38,7 +38,7 @@ class UpdateItemTypeRequest extends FormRequest
                 'integer',
                 Rule::exists('ecc_storage_categories', 'id')->whereNull('deleted_at'),
             ],
-            'description'  => 'nullable|string',
+            'description'  => 'nullable|string|max:1000',
             'icon'         => 'nullable|string|max:100',
             'stackable'    => 'sometimes|boolean',
             'max_quantity'  => 'nullable|integer|min:1',

--- a/v3/app/Http/Requests/UpdateSettingRequest.php
+++ b/v3/app/Http/Requests/UpdateSettingRequest.php
@@ -25,7 +25,7 @@ class UpdateSettingRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'key'   => 'required|string|in:transfers_enabled',
+            'key'   => 'required|string|in:transfers_enabled,broker_fee_sonuren',
             'value' => 'required|string',
         ];
     }

--- a/v3/app/Http/Requests/UpdateSettingRequest.php
+++ b/v3/app/Http/Requests/UpdateSettingRequest.php
@@ -36,8 +36,9 @@ class UpdateSettingRequest extends FormRequest
         }
 
         return [
-            'key'   => 'required|string|in:transfers_enabled,broker_fee_sonuren',
-            'value' => $valueRules,
+            'key'      => 'required|string|in:transfers_enabled,broker_fee_sonuren',
+            'value'    => $valueRules,
+            'actor_id' => 'required|integer',
         ];
     }
 }

--- a/v3/app/Http/Requests/UpdateSettingRequest.php
+++ b/v3/app/Http/Requests/UpdateSettingRequest.php
@@ -24,9 +24,20 @@ class UpdateSettingRequest extends FormRequest
      */
     public function rules(): array
     {
+        $key = $this->input('key');
+
+        $valueRules = ['required', 'string'];
+
+        if ($key === 'transfers_enabled') {
+            $valueRules[] = 'in:0,1';
+        } elseif ($key === 'broker_fee_sonuren') {
+            $valueRules[] = 'integer';
+            $valueRules[] = 'min:0';
+        }
+
         return [
             'key'   => 'required|string|in:transfers_enabled,broker_fee_sonuren',
-            'value' => 'required|string',
+            'value' => $valueRules,
         ];
     }
 }

--- a/v3/app/Http/Resources/StorageLabelTokenItemResource.php
+++ b/v3/app/Http/Resources/StorageLabelTokenItemResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * API resource for serializing a single item line within a label token.
+ */
+class StorageLabelTokenItemResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'           => $this->id,
+            'item_type_id' => $this->item_type_id,
+            'quantity'     => $this->quantity,
+            'item_type'    => new StorageItemTypeResource($this->whenLoaded('itemType')),
+        ];
+    }
+}

--- a/v3/app/Http/Resources/StorageLabelTokenResource.php
+++ b/v3/app/Http/Resources/StorageLabelTokenResource.php
@@ -20,8 +20,7 @@ class StorageLabelTokenResource extends JsonResource
         return [
             'id'              => $this->id,
             'token'           => $this->token,
-            'item_type_id'    => $this->item_type_id,
-            'quantity'        => $this->quantity,
+            'items'           => StorageLabelTokenItemResource::collection($this->whenLoaded('items')),
             'note'            => $this->note,
             'source'          => $this->source,
             'source_char_id'  => $this->source_char_id,

--- a/v3/app/Services/InventoryService.php
+++ b/v3/app/Services/InventoryService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\LogAction;
 use App\Models\StorageInventory;
 use App\Models\StorageItemType;
 use App\Models\StorageLog;
@@ -67,7 +68,7 @@ class InventoryService
                 'source_char_id'  => null,
                 'target_char_id'  => $characterId,
                 'actor_id'        => $actorId,
-                'action'          => 'mint',
+                'action'          => LogAction::Mint->value,
                 'note'            => $note,
                 'created_at'      => time(),
             ]);
@@ -123,7 +124,7 @@ class InventoryService
                 'source_char_id'  => $characterId,
                 'target_char_id'  => null,
                 'actor_id'        => $actorId,
-                'action'          => 'burn',
+                'action'          => LogAction::Burn->value,
                 'note'            => $note,
                 'created_at'      => time(),
             ]);
@@ -180,16 +181,16 @@ class InventoryService
             $inventory->updated_at = time();
             $inventory->save();
 
-            $action = $delta > 0 ? 'mint' : 'burn';
+            $action = $delta > 0 ? LogAction::Mint : LogAction::Burn;
             $characterId = $inventory->character_id;
 
             StorageLog::create([
                 'item_type_id'    => $inventory->item_type_id,
                 'quantity'        => abs($delta),
-                'source_char_id'  => $action === 'burn' ? $characterId : null,
-                'target_char_id'  => $action === 'mint' ? $characterId : null,
+                'source_char_id'  => $action === LogAction::Burn ? $characterId : null,
+                'target_char_id'  => $action === LogAction::Mint ? $characterId : null,
                 'actor_id'        => $actorId,
-                'action'          => $action,
+                'action'          => $action->value,
                 'note'            => $note,
                 'created_at'      => time(),
             ]);

--- a/v3/app/Services/LabelService.php
+++ b/v3/app/Services/LabelService.php
@@ -169,10 +169,12 @@ class LabelService
                 throw new \DomainException('Label token has expired.');
             }
 
-            $tokenItems = StorageLabelTokenItem::where('label_token_id', $lockedToken->id)->get();
+            $tokenItems = StorageLabelTokenItem::where('label_token_id', $lockedToken->id)
+                ->with('itemType')
+                ->get();
 
             foreach ($tokenItems as $tokenItem) {
-                $itemType = StorageItemType::findOrFail($tokenItem->item_type_id);
+                $itemType = $tokenItem->itemType;
 
                 $inventory = StorageInventory::where('character_id', $charId)
                     ->where('item_type_id', $tokenItem->item_type_id)

--- a/v3/app/Services/LabelService.php
+++ b/v3/app/Services/LabelService.php
@@ -98,6 +98,18 @@ class LabelService
     }
 
     /**
+     * Return all tokens, ordered newest-first, with items eager-loaded.
+     *
+     * @return Collection<int, StorageLabelToken>
+     */
+    public function getAll(): Collection
+    {
+        return StorageLabelToken::with('items.itemType')
+            ->orderByDesc('created_at')
+            ->get();
+    }
+
+    /**
      * Return all unclaimed tokens, ordered newest-first, with items eager-loaded.
      *
      * @return Collection<int, StorageLabelToken>
@@ -245,11 +257,15 @@ class LabelService
                     ->lockForUpdate()
                     ->first();
 
-                $currentQty = $inventory ? $inventory->quantity : 0;
-
-                if ($currentQty < $quantity) {
+                if ($inventory === null) {
                     throw new \DomainException(
-                        "Insufficient quantity: have {$currentQty}, tried to burn {$quantity}."
+                        "No inventory found for character {$data['source_char_id']} and item type {$item['item_type_id']}."
+                    );
+                }
+
+                if ($inventory->quantity < $quantity) {
+                    throw new \DomainException(
+                        "Insufficient quantity: have {$inventory->quantity}, tried to burn {$quantity}."
                     );
                 }
 

--- a/v3/app/Services/LabelService.php
+++ b/v3/app/Services/LabelService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Enums\LabelTokenSource;
 use App\Models\StorageInventory;
+use App\Enums\LogAction;
 use App\Models\StorageItemType;
 use App\Models\StorageLabelToken;
 use App\Models\StorageLabelTokenItem;
@@ -208,7 +209,7 @@ class LabelService
                     'source_char_id' => null,
                     'target_char_id' => $charId,
                     'actor_id'       => $actorId,
-                    'action'         => 'label_claim',
+                    'action'         => LogAction::LabelClaim->value,
                     'brokered'       => false,
                     'note'           => $lockedToken->note,
                     'created_at'     => time(),
@@ -281,7 +282,7 @@ class LabelService
                     'source_char_id' => $data['source_char_id'],
                     'target_char_id' => null,
                     'actor_id'       => $actorId,
-                    'action'         => 'label_burn',
+                    'action'         => LogAction::LabelBurn->value,
                     'brokered'       => false,
                     'note'           => $data['note'] ?? null,
                     'created_at'     => time(),

--- a/v3/app/Services/TransferService.php
+++ b/v3/app/Services/TransferService.php
@@ -183,11 +183,13 @@ class TransferService
             ->lockForUpdate()
             ->first();
 
-        $currentBalance = $sonurenInventory ? $sonurenInventory->quantity : 0;
+        if ($sonurenInventory === null) {
+            throw new \DomainException('No Sonuren inventory for character ' . $sourceCharId . '.');
+        }
 
-        if ($currentBalance < $fee) {
+        if ($sonurenInventory->quantity < $fee) {
             throw new \DomainException(
-                "Insufficient Sonuren for broker fee: have {$currentBalance}, need {$fee}."
+                "Insufficient Sonuren for broker fee: have {$sonurenInventory->quantity}, need {$fee}."
             );
         }
 

--- a/v3/app/Services/TransferService.php
+++ b/v3/app/Services/TransferService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\LogAction;
 use App\Exceptions\TransfersLockedException;
 use App\Models\StorageInventory;
 use App\Models\StorageItemType;
@@ -141,7 +142,7 @@ class TransferService
                 'source_char_id'  => $sourceCharId,
                 'target_char_id'  => $targetCharId,
                 'actor_id'        => $actorId,
-                'action'          => 'transfer',
+                'action'          => LogAction::Transfer->value,
                 'brokered'        => $brokered,
                 'note'            => $note,
                 'created_at'      => time(),
@@ -203,7 +204,7 @@ class TransferService
             'source_char_id'  => $sourceCharId,
             'target_char_id'  => null,
             'actor_id'        => $actorId,
-            'action'          => 'broker_fee',
+            'action'          => LogAction::BrokerFee->value,
             'brokered'        => true,
             'note'            => null,
             'created_at'      => time(),

--- a/v3/database/migrations/2026_03_28_000001_add_unique_inventory_index.php
+++ b/v3/database/migrations/2026_03_28_000001_add_unique_inventory_index.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds a unique composite index on (character_id, item_type_id) to prevent
+ * duplicate inventory rows created by concurrent first-mint race conditions.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ecc_storage_inventory', function (Blueprint $table) {
+            $table->unique(['character_id', 'item_type_id'], 'inventory_character_item_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ecc_storage_inventory', function (Blueprint $table) {
+            $table->dropUnique('inventory_character_item_unique');
+        });
+    }
+};

--- a/v3/routes/api.php
+++ b/v3/routes/api.php
@@ -1,8 +1,47 @@
 <?php
 
-use Illuminate\Http\Request;
+use App\Http\Controllers\Api\CategoryController;
+use App\Http\Controllers\Api\InventoryController;
+use App\Http\Controllers\Api\ItemTypeController;
+use App\Http\Controllers\Api\LabelController;
+use App\Http\Controllers\Api\LogController;
+use App\Http\Controllers\Api\SettingsController;
+use App\Http\Controllers\Api\TransferController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:sanctum');
+Route::prefix('v3/storage')->middleware('auth:sanctum')->group(function () {
+
+    // READ — require storage:read ability
+    Route::middleware('require-ability:storage:read')->group(function () {
+        Route::get('categories', [CategoryController::class, 'index']);
+        Route::get('categories/{id}', [CategoryController::class, 'show']);
+        Route::get('item-types', [ItemTypeController::class, 'index']);
+        Route::get('item-types/{id}', [ItemTypeController::class, 'show']);
+        Route::get('inventory', [InventoryController::class, 'index']);
+        Route::get('log', [LogController::class, 'index']);
+        Route::get('settings', [SettingsController::class, 'index']);
+        Route::get('labels', [LabelController::class, 'index']);
+    });
+
+    // WRITE — require storage:write ability
+    Route::middleware('require-ability:storage:write')->group(function () {
+        Route::post('inventory', [InventoryController::class, 'store']);
+        Route::patch('inventory/{id}', [InventoryController::class, 'adjust']);
+        Route::delete('inventory/{id}', [InventoryController::class, 'destroy']);
+        Route::post('transfer', [TransferController::class, 'store']);
+        Route::post('labels/claim', [LabelController::class, 'claim']);
+    });
+
+    // ADMIN — require storage:admin ability
+    Route::middleware('require-ability:storage:admin')->group(function () {
+        Route::post('categories', [CategoryController::class, 'store']);
+        Route::put('categories/{id}', [CategoryController::class, 'update']);
+        Route::delete('categories/{id}', [CategoryController::class, 'destroy']);
+        Route::post('item-types', [ItemTypeController::class, 'store']);
+        Route::put('item-types/{id}', [ItemTypeController::class, 'update']);
+        Route::delete('item-types/{id}', [ItemTypeController::class, 'destroy']);
+        Route::post('inventory/bulk', [InventoryController::class, 'bulk']);
+        Route::put('settings', [SettingsController::class, 'update']);
+        Route::post('labels', [LabelController::class, 'store']);
+    });
+});

--- a/v3/tests/Feature/Api/CategoryControllerTest.php
+++ b/v3/tests/Feature/Api/CategoryControllerTest.php
@@ -103,7 +103,7 @@ class CategoryControllerTest extends TestCase
         $auth = $this->createConsumerWithToken(['storage:admin']);
 
         $response = $this->withToken($auth['token'])
-            ->postJson('/api/v3/storage/categories', ['name' => 'Armor']);
+            ->postJson('/api/v3/storage/categories', ['name' => 'Armor', 'actor_id' => 1]);
 
         $response->assertCreated()
             ->assertJsonPath('data.name', 'Armor');
@@ -126,7 +126,7 @@ class CategoryControllerTest extends TestCase
         $this->createCategory(['name' => 'Armor']);
 
         $this->withToken($auth['token'])
-            ->postJson('/api/v3/storage/categories', ['name' => 'Armor'])
+            ->postJson('/api/v3/storage/categories', ['name' => 'Armor', 'actor_id' => 1])
             ->assertUnprocessable();
     }
 

--- a/v3/tests/Feature/Api/CategoryControllerTest.php
+++ b/v3/tests/Feature/Api/CategoryControllerTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\ApiConsumer;
+use App\Models\StorageCategory;
+use App\Models\StorageItemType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Feature tests for CategoryController covering CRUD, is_system guards,
+ * delete-with-active-item-types check, and auth/ability enforcement.
+ */
+class CategoryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Create an ApiConsumer with a Sanctum token bearing the given abilities.
+     *
+     * @param  string[] $abilities
+     * @return array{consumer: ApiConsumer, token: string}
+     */
+    private function createConsumerWithToken(array $abilities): array
+    {
+        $consumer = ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+        $token = $consumer->createToken('test', $abilities)->plainTextToken;
+
+        return ['consumer' => $consumer, 'token' => $token];
+    }
+
+    /**
+     * Create a category with sensible defaults.
+     */
+    private function createCategory(array $overrides = []): StorageCategory
+    {
+        return StorageCategory::create(array_merge([
+            'name'       => 'Test Category',
+            'created_at' => time(),
+            'created_by' => 1,
+        ], $overrides));
+    }
+
+    // ── Index ───────────────────────────────────────────────────────────
+
+    public function test_index_returns_active_categories(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $this->createCategory(['name' => 'Weapons']);
+        $this->createCategory(['name' => 'Deleted', 'deleted_at' => time()]);
+
+        $response = $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/categories');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Weapons');
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/v3/storage/categories')
+            ->assertUnauthorized();
+    }
+
+    public function test_index_requires_read_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/categories')
+            ->assertForbidden();
+    }
+
+    // ── Show ────────────────────────────────────────────────────────────
+
+    public function test_show_returns_single_category(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $category = $this->createCategory(['name' => 'Resources']);
+
+        $this->withToken($auth['token'])
+            ->getJson("/api/v3/storage/categories/{$category->id}")
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Resources');
+    }
+
+    public function test_show_returns_404_for_deleted_category(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $category = $this->createCategory(['deleted_at' => time()]);
+
+        $this->withToken($auth['token'])
+            ->getJson("/api/v3/storage/categories/{$category->id}")
+            ->assertNotFound();
+    }
+
+    // ── Store ───────────────────────────────────────────────────────────
+
+    public function test_store_creates_category(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/categories', ['name' => 'Armor']);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.name', 'Armor');
+
+        $this->assertDatabaseHas('ecc_storage_categories', ['name' => 'Armor']);
+    }
+
+    public function test_store_requires_admin_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/categories', ['name' => 'Armor'])
+            ->assertForbidden();
+    }
+
+    public function test_store_validates_unique_name(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $this->createCategory(['name' => 'Armor']);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/categories', ['name' => 'Armor'])
+            ->assertUnprocessable();
+    }
+
+    // ── Update ──────────────────────────────────────────────────────────
+
+    public function test_update_renames_category(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory(['name' => 'Old Name']);
+
+        $this->withToken($auth['token'])
+            ->putJson("/api/v3/storage/categories/{$category->id}", ['name' => 'New Name'])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'New Name');
+    }
+
+    public function test_update_rejects_system_category(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory(['name' => 'Currency', 'is_system' => true]);
+
+        $this->withToken($auth['token'])
+            ->putJson("/api/v3/storage/categories/{$category->id}", ['name' => 'Money'])
+            ->assertForbidden();
+    }
+
+    // ── Destroy ─────────────────────────────────────────────────────────
+
+    public function test_destroy_soft_deletes_category(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory();
+
+        $this->withToken($auth['token'])
+            ->deleteJson("/api/v3/storage/categories/{$category->id}")
+            ->assertNoContent();
+
+        $this->assertNotNull(StorageCategory::find($category->id)->deleted_at);
+    }
+
+    public function test_destroy_rejects_system_category(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory(['is_system' => true]);
+
+        $this->withToken($auth['token'])
+            ->deleteJson("/api/v3/storage/categories/{$category->id}")
+            ->assertForbidden();
+    }
+
+    public function test_destroy_rejects_category_with_active_item_types(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory();
+
+        StorageItemType::create([
+            'name'        => 'Sword',
+            'category_id' => $category->id,
+            'stackable'   => true,
+            'is_system'   => false,
+            'created_at'  => time(),
+            'created_by'  => 1,
+            'updated_at'  => time(),
+        ]);
+
+        $this->withToken($auth['token'])
+            ->deleteJson("/api/v3/storage/categories/{$category->id}")
+            ->assertStatus(409);
+    }
+
+    public function test_destroy_allows_category_with_only_deleted_item_types(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory();
+
+        StorageItemType::create([
+            'name'        => 'Old Sword',
+            'category_id' => $category->id,
+            'stackable'   => true,
+            'is_system'   => false,
+            'created_at'  => time(),
+            'created_by'  => 1,
+            'updated_at'  => time(),
+            'deleted_at'  => time(),
+        ]);
+
+        $this->withToken($auth['token'])
+            ->deleteJson("/api/v3/storage/categories/{$category->id}")
+            ->assertNoContent();
+    }
+}

--- a/v3/tests/Feature/Api/InventoryControllerTest.php
+++ b/v3/tests/Feature/Api/InventoryControllerTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\ApiConsumer;
+use App\Models\StorageCategory;
+use App\Models\StorageInventory;
+use App\Models\StorageItemType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Feature tests for InventoryController covering mint, adjust, burn,
+ * bulk operations (201/207/422), max_quantity cap, and auth enforcement.
+ */
+class InventoryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Create an ApiConsumer with a Sanctum token bearing the given abilities.
+     *
+     * @param  string[] $abilities
+     * @return array{consumer: ApiConsumer, token: string}
+     */
+    private function createConsumerWithToken(array $abilities): array
+    {
+        $consumer = ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+        $token = $consumer->createToken('test', $abilities)->plainTextToken;
+
+        return ['consumer' => $consumer, 'token' => $token];
+    }
+
+    /**
+     * Create an item type with a category for testing.
+     */
+    private function createItemType(array $overrides = []): StorageItemType
+    {
+        $category = StorageCategory::create([
+            'name'       => 'Cat-' . uniqid(),
+            'created_at' => time(),
+            'created_by' => 1,
+        ]);
+
+        return StorageItemType::create(array_merge([
+            'name'        => 'Item-' . uniqid(),
+            'category_id' => $category->id,
+            'stackable'   => true,
+            'is_system'   => false,
+            'created_at'  => time(),
+            'created_by'  => 1,
+            'updated_at'  => time(),
+        ], $overrides));
+    }
+
+    // ── Index ───────────────────────────────────────────────────────────
+
+    public function test_index_returns_inventory_for_character(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $itemType = $this->createItemType();
+
+        StorageInventory::create([
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 10,
+            'updated_at'   => time(),
+        ]);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/inventory?char_id=100')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.quantity', 10);
+    }
+
+    public function test_index_requires_char_id(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/inventory')
+            ->assertUnprocessable();
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/v3/storage/inventory?char_id=1')
+            ->assertUnauthorized();
+    }
+
+    // ── Store (Mint) ────────────────────────────────────────────────────
+
+    public function test_store_mints_items(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $itemType = $this->createItemType();
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/inventory', [
+                'character_id' => 100,
+                'item_type_id' => $itemType->id,
+                'quantity'     => 5,
+                'actor_id'     => 1,
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.quantity', 5);
+
+        $this->assertDatabaseHas('ecc_storage_inventory', [
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 5,
+        ]);
+
+        $this->assertDatabaseHas('ecc_storage_log', [
+            'item_type_id'   => $itemType->id,
+            'quantity'       => 5,
+            'target_char_id' => 100,
+            'action'         => 'mint',
+        ]);
+    }
+
+    public function test_store_rejects_when_max_quantity_exceeded(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $itemType = $this->createItemType(['max_quantity' => 10]);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/inventory', [
+                'character_id' => 100,
+                'item_type_id' => $itemType->id,
+                'quantity'     => 11,
+                'actor_id'     => 1,
+            ])
+            ->assertUnprocessable();
+    }
+
+    public function test_store_requires_write_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $itemType = $this->createItemType();
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/inventory', [
+                'character_id' => 100,
+                'item_type_id' => $itemType->id,
+                'quantity'     => 5,
+                'actor_id'     => 1,
+            ])
+            ->assertForbidden();
+    }
+
+    // ── Adjust ──────────────────────────────────────────────────────────
+
+    public function test_adjust_modifies_quantity_by_delta(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $itemType = $this->createItemType();
+
+        $inventory = StorageInventory::create([
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 10,
+            'updated_at'   => time(),
+        ]);
+
+        $this->withToken($auth['token'])
+            ->patchJson("/api/v3/storage/inventory/{$inventory->id}", [
+                'quantity' => -3,
+                'actor_id' => 1,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.quantity', 7);
+    }
+
+    // ── Destroy (Burn) ──────────────────────────────────────────────────
+
+    public function test_destroy_burns_items(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $itemType = $this->createItemType();
+
+        $inventory = StorageInventory::create([
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 10,
+            'updated_at'   => time(),
+        ]);
+
+        $this->withToken($auth['token'])
+            ->deleteJson("/api/v3/storage/inventory/{$inventory->id}", [
+                'quantity' => 3,
+                'actor_id' => 1,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.quantity', 7);
+
+        $this->assertDatabaseHas('ecc_storage_log', [
+            'item_type_id'   => $itemType->id,
+            'quantity'       => 3,
+            'source_char_id' => 100,
+            'action'         => 'burn',
+        ]);
+    }
+
+    // ── Bulk ────────────────────────────────────────────────────────────
+
+    public function test_bulk_all_succeed_returns_201(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $itemType = $this->createItemType();
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/inventory/bulk', [
+                'item_type_id'  => $itemType->id,
+                'quantity'      => 5,
+                'character_ids' => [101, 102, 103],
+                'actor_id'      => 1,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('total_attempted', 3)
+            ->assertJsonPath('total_succeeded', 3)
+            ->assertJsonPath('total_failed', 0);
+    }
+
+    public function test_bulk_partial_failure_returns_207(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $itemType = $this->createItemType(['max_quantity' => 5]);
+
+        // Pre-fill one character to the cap
+        StorageInventory::create([
+            'character_id' => 101,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 5,
+            'updated_at'   => time(),
+        ]);
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/inventory/bulk', [
+                'item_type_id'  => $itemType->id,
+                'quantity'      => 3,
+                'character_ids' => [101, 102],
+                'actor_id'      => 1,
+            ]);
+
+        $response->assertStatus(207)
+            ->assertJsonPath('total_succeeded', 1)
+            ->assertJsonPath('total_failed', 1);
+    }
+
+    public function test_bulk_all_fail_returns_422(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $itemType = $this->createItemType(['max_quantity' => 1]);
+
+        StorageInventory::create([
+            'character_id' => 101,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 1,
+            'updated_at'   => time(),
+        ]);
+        StorageInventory::create([
+            'character_id' => 102,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 1,
+            'updated_at'   => time(),
+        ]);
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/inventory/bulk', [
+                'item_type_id'  => $itemType->id,
+                'quantity'      => 1,
+                'character_ids' => [101, 102],
+                'actor_id'      => 1,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('total_succeeded', 0)
+            ->assertJsonPath('total_failed', 2);
+    }
+
+    public function test_bulk_requires_admin_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $itemType = $this->createItemType();
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/inventory/bulk', [
+                'item_type_id'  => $itemType->id,
+                'quantity'      => 5,
+                'character_ids' => [101],
+                'actor_id'      => 1,
+            ])
+            ->assertForbidden();
+    }
+}

--- a/v3/tests/Feature/Api/ItemTypeControllerTest.php
+++ b/v3/tests/Feature/Api/ItemTypeControllerTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\ApiConsumer;
+use App\Models\StorageCategory;
+use App\Models\StorageItemType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Feature tests for ItemTypeController covering CRUD, is_system guards,
+ * category_name in response, and auth/ability enforcement.
+ */
+class ItemTypeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Create an ApiConsumer with a Sanctum token bearing the given abilities.
+     *
+     * @param  string[] $abilities
+     * @return array{consumer: ApiConsumer, token: string}
+     */
+    private function createConsumerWithToken(array $abilities): array
+    {
+        $consumer = ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+        $token = $consumer->createToken('test', $abilities)->plainTextToken;
+
+        return ['consumer' => $consumer, 'token' => $token];
+    }
+
+    /**
+     * Create a category with sensible defaults.
+     */
+    private function createCategory(array $overrides = []): StorageCategory
+    {
+        return StorageCategory::create(array_merge([
+            'name'       => 'Test Category',
+            'created_at' => time(),
+            'created_by' => 1,
+        ], $overrides));
+    }
+
+    /**
+     * Create an item type with sensible defaults.
+     */
+    private function createItemType(array $overrides = []): StorageItemType
+    {
+        if (! isset($overrides['category_id'])) {
+            $overrides['category_id'] = $this->createCategory()->id;
+        }
+
+        return StorageItemType::create(array_merge([
+            'name'        => 'Test Item',
+            'category_id' => $overrides['category_id'],
+            'stackable'   => true,
+            'is_system'   => false,
+            'created_at'  => time(),
+            'created_by'  => 1,
+            'updated_at'  => time(),
+        ], $overrides));
+    }
+
+    // ── Index ───────────────────────────────────────────────────────────
+
+    public function test_index_returns_active_item_types_with_category_name(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $category = $this->createCategory(['name' => 'Weapons']);
+        $this->createItemType(['name' => 'Sword', 'category_id' => $category->id]);
+        $this->createItemType(['name' => 'Deleted', 'category_id' => $category->id, 'deleted_at' => time()]);
+
+        $response = $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/item-types');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Sword')
+            ->assertJsonPath('data.0.category_name', 'Weapons');
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/v3/storage/item-types')
+            ->assertUnauthorized();
+    }
+
+    public function test_index_requires_read_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/item-types')
+            ->assertForbidden();
+    }
+
+    // ── Show ────────────────────────────────────────────────────────────
+
+    public function test_show_returns_item_type_with_category_name(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $category = $this->createCategory(['name' => 'Resources']);
+        $itemType = $this->createItemType(['name' => 'Wood', 'category_id' => $category->id]);
+
+        $this->withToken($auth['token'])
+            ->getJson("/api/v3/storage/item-types/{$itemType->id}")
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Wood')
+            ->assertJsonPath('data.category_name', 'Resources');
+    }
+
+    public function test_show_returns_404_for_deleted_item_type(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $itemType = $this->createItemType(['deleted_at' => time()]);
+
+        $this->withToken($auth['token'])
+            ->getJson("/api/v3/storage/item-types/{$itemType->id}")
+            ->assertNotFound();
+    }
+
+    // ── Store ───────────────────────────────────────────────────────────
+
+    public function test_store_creates_item_type(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory();
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/item-types', [
+                'name'         => 'Health Potion',
+                'category_id'  => $category->id,
+                'stackable'    => true,
+                'max_quantity'  => 50,
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.name', 'Health Potion')
+            ->assertJsonPath('data.max_quantity', 50);
+
+        $this->assertDatabaseHas('ecc_storage_item_types', ['name' => 'Health Potion']);
+    }
+
+    public function test_store_requires_admin_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $category = $this->createCategory();
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/item-types', [
+                'name'        => 'Sword',
+                'category_id' => $category->id,
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_store_validates_category_exists(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/item-types', [
+                'name'        => 'Sword',
+                'category_id' => 99999,
+            ])
+            ->assertUnprocessable();
+    }
+
+    // ── Update ──────────────────────────────────────────────────────────
+
+    public function test_update_modifies_item_type(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory();
+        $itemType = $this->createItemType(['name' => 'Old Name', 'category_id' => $category->id]);
+
+        $this->withToken($auth['token'])
+            ->putJson("/api/v3/storage/item-types/{$itemType->id}", [
+                'name'        => 'New Name',
+                'category_id' => $category->id,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'New Name');
+    }
+
+    public function test_update_rejects_system_item_type(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $category = $this->createCategory();
+        $itemType = $this->createItemType([
+            'name'        => 'Sonuren',
+            'category_id' => $category->id,
+            'is_system'   => true,
+        ]);
+
+        $this->withToken($auth['token'])
+            ->putJson("/api/v3/storage/item-types/{$itemType->id}", [
+                'name'        => 'Gold',
+                'category_id' => $category->id,
+            ])
+            ->assertForbidden();
+    }
+
+    // ── Destroy ─────────────────────────────────────────────────────────
+
+    public function test_destroy_soft_deletes_item_type(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $itemType = $this->createItemType();
+
+        $this->withToken($auth['token'])
+            ->deleteJson("/api/v3/storage/item-types/{$itemType->id}")
+            ->assertNoContent();
+
+        $this->assertNotNull(StorageItemType::find($itemType->id)->deleted_at);
+    }
+
+    public function test_destroy_rejects_system_item_type(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $itemType = $this->createItemType(['is_system' => true]);
+
+        $this->withToken($auth['token'])
+            ->deleteJson("/api/v3/storage/item-types/{$itemType->id}")
+            ->assertForbidden();
+    }
+}

--- a/v3/tests/Feature/Api/ItemTypeControllerTest.php
+++ b/v3/tests/Feature/Api/ItemTypeControllerTest.php
@@ -133,6 +133,7 @@ class ItemTypeControllerTest extends TestCase
                 'category_id'  => $category->id,
                 'stackable'    => true,
                 'max_quantity'  => 50,
+                'actor_id'     => 1,
             ]);
 
         $response->assertCreated()

--- a/v3/tests/Feature/Api/LabelControllerTest.php
+++ b/v3/tests/Feature/Api/LabelControllerTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\ApiConsumer;
+use App\Models\StorageCategory;
+use App\Models\StorageInventory;
+use App\Models\StorageItemType;
+use App\Models\StorageLabelToken;
+use App\Models\StorageLabelTokenItem;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Feature tests for LabelController covering get by token, get unclaimed,
+ * create mint/burn, claim happy path, double claim, expired, and auth.
+ */
+class LabelControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Create an ApiConsumer with a Sanctum token bearing the given abilities.
+     *
+     * @param  string[] $abilities
+     * @return array{consumer: ApiConsumer, token: string}
+     */
+    private function createConsumerWithToken(array $abilities): array
+    {
+        $consumer = ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+        $token = $consumer->createToken('test', $abilities)->plainTextToken;
+
+        return ['consumer' => $consumer, 'token' => $token];
+    }
+
+    /**
+     * Create an item type with a category.
+     */
+    private function createItemType(array $overrides = []): StorageItemType
+    {
+        $category = StorageCategory::firstOrCreate(
+            ['name' => 'Test Category'],
+            ['created_at' => time(), 'created_by' => 1]
+        );
+
+        return StorageItemType::create(array_merge([
+            'name'        => 'Item-' . uniqid(),
+            'category_id' => $category->id,
+            'stackable'   => true,
+            'is_system'   => false,
+            'created_at'  => time(),
+            'created_by'  => 1,
+            'updated_at'  => time(),
+        ], $overrides));
+    }
+
+    /**
+     * Create a label token with one item line.
+     */
+    private function createLabelToken(int $itemTypeId, array $overrides = []): StorageLabelToken
+    {
+        $token = StorageLabelToken::create(array_merge([
+            'token'          => fake()->uuid(),
+            'note'           => 'test label',
+            'source'         => 'mint',
+            'source_char_id' => null,
+            'created_by'     => 1,
+            'created_at'     => time(),
+        ], $overrides));
+
+        StorageLabelTokenItem::create([
+            'label_token_id' => $token->id,
+            'item_type_id'   => $itemTypeId,
+            'quantity'       => 5,
+        ]);
+
+        return $token;
+    }
+
+    // ── GET by token ────────────────────────────────────────────────────
+
+    public function test_index_by_token_returns_single_label(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $itemType = $this->createItemType();
+        $label = $this->createLabelToken($itemType->id);
+
+        $this->withToken($auth['token'])
+            ->getJson("/api/v3/storage/labels?token={$label->token}")
+            ->assertOk()
+            ->assertJsonPath('data.token', $label->token);
+    }
+
+    public function test_index_by_token_returns_404_when_not_found(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/labels?token=00000000-0000-0000-0000-000000000000')
+            ->assertNotFound();
+    }
+
+    // ── GET unclaimed ───────────────────────────────────────────────────
+
+    public function test_index_unclaimed_returns_unclaimed_tokens(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $itemType = $this->createItemType();
+        $this->createLabelToken($itemType->id);
+        $this->createLabelToken($itemType->id, ['claimed_by' => 100, 'claimed_at' => time()]);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/labels?unclaimed=1')
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    // ── POST create (mint source) ───────────────────────────────────────
+
+    public function test_store_creates_mint_label(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $itemType = $this->createItemType();
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/labels', [
+                'items' => [
+                    ['item_type_id' => $itemType->id, 'quantity' => 3],
+                ],
+                'source'   => 'mint',
+                'actor_id' => 1,
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.source', 'mint')
+            ->assertJsonCount(1, 'data.items');
+
+        $this->assertDatabaseCount('ecc_storage_label_tokens', 1);
+        $this->assertDatabaseCount('ecc_storage_label_token_items', 1);
+    }
+
+    // ── POST create (burn source) ───────────────────────────────────────
+
+    public function test_store_creates_burn_label_and_deducts_inventory(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $itemType = $this->createItemType();
+
+        StorageInventory::create([
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 10,
+            'updated_at'   => time(),
+        ]);
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/labels', [
+                'items' => [
+                    ['item_type_id' => $itemType->id, 'quantity' => 3],
+                ],
+                'source'         => 'burn',
+                'source_char_id' => 100,
+                'actor_id'       => 1,
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.source', 'burn');
+
+        $this->assertDatabaseHas('ecc_storage_inventory', [
+            'character_id' => 100,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 7,
+        ]);
+    }
+
+    public function test_store_requires_admin_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/labels', [])
+            ->assertForbidden();
+    }
+
+    // ── POST claim ──────────────────────────────────────────────────────
+
+    public function test_claim_mints_items_to_character(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $itemType = $this->createItemType();
+        $label = $this->createLabelToken($itemType->id);
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/labels/claim', [
+                'token'        => $label->token,
+                'character_id' => 200,
+                'actor_id'     => 1,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.claimed_by', 200);
+
+        $this->assertDatabaseHas('ecc_storage_inventory', [
+            'character_id' => 200,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 5,
+        ]);
+
+        $this->assertDatabaseHas('ecc_storage_log', [
+            'action'         => 'label_claim',
+            'target_char_id' => 200,
+        ]);
+    }
+
+    public function test_claim_double_claim_returns_422(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $itemType = $this->createItemType();
+        $label = $this->createLabelToken($itemType->id, [
+            'claimed_by' => 100,
+            'claimed_at' => time(),
+        ]);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/labels/claim', [
+                'token'        => $label->token,
+                'character_id' => 200,
+                'actor_id'     => 1,
+            ])
+            ->assertUnprocessable();
+    }
+
+    public function test_claim_expired_token_returns_422(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $itemType = $this->createItemType();
+        $label = $this->createLabelToken($itemType->id, [
+            'expires_at' => time() - 3600,
+        ]);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/labels/claim', [
+                'token'        => $label->token,
+                'character_id' => 200,
+                'actor_id'     => 1,
+            ])
+            ->assertUnprocessable();
+    }
+
+    public function test_claim_requires_write_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/labels/claim', [])
+            ->assertForbidden();
+    }
+
+    // ── Auth ────────────────────────────────────────────────────────────
+
+    public function test_labels_require_authentication(): void
+    {
+        $this->getJson('/api/v3/storage/labels')
+            ->assertUnauthorized();
+    }
+}

--- a/v3/tests/Feature/Api/LogControllerTest.php
+++ b/v3/tests/Feature/Api/LogControllerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\ApiConsumer;
+use App\Models\StorageLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Feature tests for LogController covering char_id UNION ALL filter,
+ * item_type_id filter, brokered exclusion, include_brokered, pagination, and auth.
+ */
+class LogControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Create an ApiConsumer with a Sanctum token bearing the given abilities.
+     *
+     * @param  string[] $abilities
+     * @return array{consumer: ApiConsumer, token: string}
+     */
+    private function createConsumerWithToken(array $abilities): array
+    {
+        $consumer = ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+        $token = $consumer->createToken('test', $abilities)->plainTextToken;
+
+        return ['consumer' => $consumer, 'token' => $token];
+    }
+
+    /**
+     * Create a log entry with sensible defaults.
+     */
+    private function createLog(array $overrides = []): StorageLog
+    {
+        return StorageLog::create(array_merge([
+            'item_type_id'   => 1,
+            'quantity'       => 1,
+            'source_char_id' => null,
+            'target_char_id' => null,
+            'actor_id'       => 1,
+            'action'         => 'mint',
+            'brokered'       => false,
+            'note'           => null,
+            'created_at'     => time(),
+        ], $overrides));
+    }
+
+    // ── Basic listing ───────────────────────────────────────────────────
+
+    public function test_index_returns_log_entries(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $this->createLog();
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/log')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonStructure(['data', 'page', 'per_page', 'has_more']);
+    }
+
+    // ── char_id UNION ALL filter ────────────────────────────────────────
+
+    public function test_char_id_returns_source_and_target_entries(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+
+        // char 10 as source
+        $this->createLog(['source_char_id' => 10, 'target_char_id' => 20, 'action' => 'transfer']);
+        // char 10 as target
+        $this->createLog(['source_char_id' => 30, 'target_char_id' => 10, 'action' => 'transfer']);
+        // unrelated
+        $this->createLog(['source_char_id' => 30, 'target_char_id' => 40, 'action' => 'transfer']);
+
+        $response = $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/log?char_id=10');
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data');
+    }
+
+    // ── item_type_id filter ─────────────────────────────────────────────
+
+    public function test_item_type_id_filter(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $this->createLog(['item_type_id' => 1]);
+        $this->createLog(['item_type_id' => 2]);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/log?item_type_id=1')
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    // ── Brokered exclusion ──────────────────────────────────────────────
+
+    public function test_brokered_entries_excluded_by_default(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $this->createLog(['brokered' => false]);
+        $this->createLog(['brokered' => true]);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/log')
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_include_brokered_shows_all(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $this->createLog(['brokered' => false]);
+        $this->createLog(['brokered' => true]);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/log?include_brokered=1')
+            ->assertOk()
+            ->assertJsonCount(2, 'data');
+    }
+
+    // ── Pagination ──────────────────────────────────────────────────────
+
+    public function test_pagination_with_has_more(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->createLog(['created_at' => time() + $i]);
+        }
+
+        $response = $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/log?per_page=3&page=1');
+
+        $response->assertOk()
+            ->assertJsonCount(3, 'data')
+            ->assertJsonPath('has_more', true)
+            ->assertJsonPath('page', 1)
+            ->assertJsonPath('per_page', 3);
+
+        // Page 2
+        $response2 = $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/log?per_page=3&page=2');
+
+        $response2->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('has_more', false);
+    }
+
+    // ── Auth ────────────────────────────────────────────────────────────
+
+    public function test_log_requires_authentication(): void
+    {
+        $this->getJson('/api/v3/storage/log')
+            ->assertUnauthorized();
+    }
+
+    public function test_log_requires_read_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/log')
+            ->assertForbidden();
+    }
+}

--- a/v3/tests/Feature/Api/SettingsControllerTest.php
+++ b/v3/tests/Feature/Api/SettingsControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\ApiConsumer;
+use App\Models\StorageSetting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Feature tests for SettingsController covering list, update,
+ * unknown key rejection, and auth/ability enforcement.
+ */
+class SettingsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Create an ApiConsumer with a Sanctum token bearing the given abilities.
+     *
+     * @param  string[] $abilities
+     * @return array{consumer: ApiConsumer, token: string}
+     */
+    private function createConsumerWithToken(array $abilities): array
+    {
+        $consumer = ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+        $token = $consumer->createToken('test', $abilities)->plainTextToken;
+
+        return ['consumer' => $consumer, 'token' => $token];
+    }
+
+    /**
+     * Seed the default settings.
+     */
+    private function seedSettings(): void
+    {
+        StorageSetting::firstOrCreate(
+            ['key_name' => 'transfers_enabled'],
+            ['value' => '1', 'updated_at' => time(), 'updated_by' => 0]
+        );
+        StorageSetting::firstOrCreate(
+            ['key_name' => 'broker_fee_sonuren'],
+            ['value' => '20', 'updated_at' => time(), 'updated_by' => 0]
+        );
+    }
+
+    // ── Index ───────────────────────────────────────────────────────────
+
+    public function test_index_returns_all_settings(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+        $this->seedSettings();
+
+        $this->withToken($auth['token'])
+            ->getJson('/api/v3/storage/settings')
+            ->assertOk()
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->getJson('/api/v3/storage/settings')
+            ->assertUnauthorized();
+    }
+
+    // ── Update ──────────────────────────────────────────────────────────
+
+    public function test_update_changes_setting_value(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $this->seedSettings();
+
+        $this->withToken($auth['token'])
+            ->putJson('/api/v3/storage/settings', [
+                'key'   => 'transfers_enabled',
+                'value' => '0',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.value', '0');
+
+        $this->assertDatabaseHas('ecc_storage_settings', [
+            'key_name' => 'transfers_enabled',
+            'value'    => '0',
+        ]);
+    }
+
+    public function test_update_broker_fee_sonuren(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+        $this->seedSettings();
+
+        $this->withToken($auth['token'])
+            ->putJson('/api/v3/storage/settings', [
+                'key'   => 'broker_fee_sonuren',
+                'value' => '50',
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.value', '50');
+    }
+
+    public function test_update_rejects_unknown_key(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:admin']);
+
+        $this->withToken($auth['token'])
+            ->putJson('/api/v3/storage/settings', [
+                'key'   => 'nonexistent_setting',
+                'value' => '1',
+            ])
+            ->assertUnprocessable();
+    }
+
+    public function test_update_requires_admin_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+
+        $this->withToken($auth['token'])
+            ->putJson('/api/v3/storage/settings', [
+                'key'   => 'transfers_enabled',
+                'value' => '0',
+            ])
+            ->assertForbidden();
+    }
+}

--- a/v3/tests/Feature/Api/SettingsControllerTest.php
+++ b/v3/tests/Feature/Api/SettingsControllerTest.php
@@ -72,8 +72,9 @@ class SettingsControllerTest extends TestCase
 
         $this->withToken($auth['token'])
             ->putJson('/api/v3/storage/settings', [
-                'key'   => 'transfers_enabled',
-                'value' => '0',
+                'key'      => 'transfers_enabled',
+                'value'    => '0',
+                'actor_id' => 1,
             ])
             ->assertOk()
             ->assertJsonPath('data.value', '0');
@@ -91,8 +92,9 @@ class SettingsControllerTest extends TestCase
 
         $this->withToken($auth['token'])
             ->putJson('/api/v3/storage/settings', [
-                'key'   => 'broker_fee_sonuren',
-                'value' => '50',
+                'key'      => 'broker_fee_sonuren',
+                'value'    => '50',
+                'actor_id' => 1,
             ])
             ->assertOk()
             ->assertJsonPath('data.value', '50');

--- a/v3/tests/Feature/Api/TransferControllerTest.php
+++ b/v3/tests/Feature/Api/TransferControllerTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\ApiConsumer;
+use App\Models\StorageCategory;
+use App\Models\StorageInventory;
+use App\Models\StorageItemType;
+use App\Models\StorageSetting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Feature tests for TransferController covering happy path, brokered fees,
+ * insufficient quantity, transfers locked, receiver cap, and auth enforcement.
+ */
+class TransferControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Create an ApiConsumer with a Sanctum token bearing the given abilities.
+     *
+     * @param  string[] $abilities
+     * @return array{consumer: ApiConsumer, token: string}
+     */
+    private function createConsumerWithToken(array $abilities): array
+    {
+        $consumer = ApiConsumer::create(['name' => 'test-consumer', 'created_at' => time()]);
+        $token = $consumer->createToken('test', $abilities)->plainTextToken;
+
+        return ['consumer' => $consumer, 'token' => $token];
+    }
+
+    /**
+     * Seed the settings required for transfer operations.
+     */
+    private function seedSettings(): void
+    {
+        StorageSetting::firstOrCreate(
+            ['key_name' => 'transfers_enabled'],
+            ['value' => '1', 'updated_at' => time(), 'updated_by' => 0]
+        );
+        StorageSetting::firstOrCreate(
+            ['key_name' => 'broker_fee_sonuren'],
+            ['value' => '20', 'updated_at' => time(), 'updated_by' => 0]
+        );
+    }
+
+    /**
+     * Create an item type with a category.
+     */
+    private function createItemType(array $overrides = []): StorageItemType
+    {
+        $category = StorageCategory::firstOrCreate(
+            ['name' => 'Test Category'],
+            ['created_at' => time(), 'created_by' => 1]
+        );
+
+        return StorageItemType::create(array_merge([
+            'name'        => 'Item-' . uniqid(),
+            'category_id' => $category->id,
+            'stackable'   => true,
+            'is_system'   => false,
+            'created_at'  => time(),
+            'created_by'  => 1,
+            'updated_at'  => time(),
+        ], $overrides));
+    }
+
+    /**
+     * Give a character inventory of a specific item type.
+     */
+    private function giveInventory(int $charId, int $itemTypeId, int $quantity): StorageInventory
+    {
+        return StorageInventory::create([
+            'character_id' => $charId,
+            'item_type_id' => $itemTypeId,
+            'quantity'     => $quantity,
+            'updated_at'   => time(),
+        ]);
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────────
+
+    public function test_transfer_moves_items_between_characters(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $this->seedSettings();
+        $itemType = $this->createItemType();
+        $this->giveInventory(1, $itemType->id, 10);
+
+        $response = $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/transfer', [
+                'source_char_id' => 1,
+                'target_char_id' => 2,
+                'item_type_id'   => $itemType->id,
+                'quantity'       => 3,
+                'actor_id'       => 1,
+            ]);
+
+        $response->assertCreated();
+
+        $this->assertDatabaseHas('ecc_storage_inventory', [
+            'character_id' => 1,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 7,
+        ]);
+        $this->assertDatabaseHas('ecc_storage_inventory', [
+            'character_id' => 2,
+            'item_type_id' => $itemType->id,
+            'quantity'     => 3,
+        ]);
+        $this->assertDatabaseHas('ecc_storage_log', [
+            'action'         => 'transfer',
+            'source_char_id' => 1,
+            'target_char_id' => 2,
+            'quantity'       => 3,
+        ]);
+    }
+
+    // ── Brokered ────────────────────────────────────────────────────────
+
+    public function test_brokered_transfer_deducts_fee(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $this->seedSettings();
+        $itemType = $this->createItemType();
+        $sonuren = $this->createItemType(['name' => 'Sonuren', 'is_system' => true]);
+
+        $this->giveInventory(1, $itemType->id, 10);
+        $this->giveInventory(1, $sonuren->id, 50);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/transfer', [
+                'source_char_id' => 1,
+                'target_char_id' => 2,
+                'item_type_id'   => $itemType->id,
+                'quantity'       => 3,
+                'brokered'       => true,
+                'actor_id'       => 1,
+            ])
+            ->assertCreated();
+
+        // Sonuren balance should be 50 - 20 = 30
+        $this->assertDatabaseHas('ecc_storage_inventory', [
+            'character_id' => 1,
+            'item_type_id' => $sonuren->id,
+            'quantity'     => 30,
+        ]);
+
+        $this->assertDatabaseHas('ecc_storage_log', [
+            'action'   => 'broker_fee',
+            'brokered' => 1,
+        ]);
+    }
+
+    public function test_brokered_transfer_fails_with_insufficient_sonuren(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $this->seedSettings();
+        $itemType = $this->createItemType();
+        $sonuren = $this->createItemType(['name' => 'Sonuren', 'is_system' => true]);
+
+        $this->giveInventory(1, $itemType->id, 10);
+        $this->giveInventory(1, $sonuren->id, 10); // less than 20 fee
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/transfer', [
+                'source_char_id' => 1,
+                'target_char_id' => 2,
+                'item_type_id'   => $itemType->id,
+                'quantity'       => 3,
+                'brokered'       => true,
+                'actor_id'       => 1,
+            ])
+            ->assertUnprocessable();
+    }
+
+    // ── Insufficient quantity ───────────────────────────────────────────
+
+    public function test_transfer_fails_with_insufficient_quantity(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $this->seedSettings();
+        $itemType = $this->createItemType();
+        $this->giveInventory(1, $itemType->id, 2);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/transfer', [
+                'source_char_id' => 1,
+                'target_char_id' => 2,
+                'item_type_id'   => $itemType->id,
+                'quantity'       => 5,
+                'actor_id'       => 1,
+            ])
+            ->assertUnprocessable();
+    }
+
+    // ── Transfers locked ────────────────────────────────────────────────
+
+    public function test_transfer_fails_when_transfers_disabled(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $this->seedSettings();
+        StorageSetting::where('key_name', 'transfers_enabled')->update(['value' => '0']);
+
+        $itemType = $this->createItemType();
+        $this->giveInventory(1, $itemType->id, 10);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/transfer', [
+                'source_char_id' => 1,
+                'target_char_id' => 2,
+                'item_type_id'   => $itemType->id,
+                'quantity'       => 3,
+                'actor_id'       => 1,
+            ])
+            ->assertStatus(423);
+    }
+
+    // ── Receiver cap ────────────────────────────────────────────────────
+
+    public function test_transfer_fails_when_receiver_cap_exceeded(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:write']);
+        $this->seedSettings();
+        $itemType = $this->createItemType(['max_quantity' => 5]);
+        $this->giveInventory(1, $itemType->id, 10);
+        $this->giveInventory(2, $itemType->id, 4);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/transfer', [
+                'source_char_id' => 1,
+                'target_char_id' => 2,
+                'item_type_id'   => $itemType->id,
+                'quantity'       => 3,
+                'actor_id'       => 1,
+            ])
+            ->assertUnprocessable();
+    }
+
+    // ── Auth ────────────────────────────────────────────────────────────
+
+    public function test_transfer_requires_authentication(): void
+    {
+        $this->postJson('/api/v3/storage/transfer', [])
+            ->assertUnauthorized();
+    }
+
+    public function test_transfer_requires_write_ability(): void
+    {
+        $auth = $this->createConsumerWithToken(['storage:read']);
+
+        $this->withToken($auth['token'])
+            ->postJson('/api/v3/storage/transfer', [])
+            ->assertForbidden();
+    }
+}

--- a/v3/tests/Unit/Services/TransferServiceTest.php
+++ b/v3/tests/Unit/Services/TransferServiceTest.php
@@ -406,7 +406,7 @@ class TransferServiceTest extends TestCase
         $this->seedInventory(100, $itemType->id, 5);
 
         $this->expectException(\DomainException::class);
-        $this->expectExceptionMessage('Insufficient Sonuren for broker fee');
+        $this->expectExceptionMessage('No Sonuren inventory');
         $this->service->transfer(100, 200, $itemType->id, 2, 1, true);
     }
 


### PR DESCRIPTION
## Summary

- **7 API controllers** wiring services to HTTP endpoints with ability-based auth
- **Routes** for all v3/storage endpoints grouped by read/write/admin abilities
- **Fix 3 existing files**: StorageLabelTokenResource (items relationship), UpdateSettingRequest (broker_fee_sonuren), StoreLabelTokenRequest (actor_id, expires_at)
- **New resource**: StorageLabelTokenItemResource for label token item serialization
- **7 feature test files** covering all controllers (148 tests, 319 assertions passing)
- **PLAN.md**: V3-10 through V3-14, LBL-02, LBL-03 checked off

## Controllers

| Controller | Key behavior |
|---|---|
| CategoryController | CRUD, is_system guard (403), active item types check on delete (409) |
| ItemTypeController | CRUD, is_system guard (403), eager-loads category |
| InventoryController | mint/burn/adjust + bulk with 201/207/422 status codes |
| TransferController | Delegates to TransferService; exceptions handled globally |
| LogController | UNION ALL for char_id queries, include_brokered, manual pagination |
| SettingsController | List all, update by key, unknown key rejected (422) |
| LabelController | GET by token/unclaimed, POST create (mint/burn), POST claim |

## Test plan

- [x] All 148 tests pass (`php artisan test`)
- [ ] Verify Category CRUD: create, rename, is_system 403, delete with active item types 409
- [ ] Verify Inventory: mint, adjust, burn, bulk 201/207/422, max_quantity cap
- [ ] Verify Transfer: happy path, brokered fee deduction, transfers locked 423
- [ ] Verify Log: char_id UNION ALL, brokered exclusion, pagination has_more
- [ ] Verify Settings: list, update, unknown key 422
- [ ] Verify Labels: get by token, unclaimed, create, claim, double claim 422, expired 422

Closes #102
Refs #87, #88, #89, #90, #91, #94, #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)