### PR TITLE
Feat/fix headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+
+## [Released] v1.0 - First Tagged release - HTTP Header Underscore Support & Input Normalization
+
+### Added
+- **Added CHANGELOG.md to start tracking changes:**. This will allow us to start tagging releases. 
+- **Support for `FIX_` Mapped Headers:** Enhanced `get_normalized_headers()` to scan for variables starting with a `FIX_` prefix in the `$_SERVER` superglobal. This maps and normalizes variables like `FIX_CHAR_ID` to standardized lowercase underscored (`char_id`) and hyphenated (`char-id`) formats so they merge seamlessly into the final `$input` array.
+
+### Changed
+- **Fixed Header Stripping in PHP-FPM/Apache:** Removed the dependency on `getallheaders()` inside `get_normalized_headers()`. This ensures that even when Apache filters out custom headers containing underscores from its native request header array, the PHP fallback block parsing the `$_SERVER` superglobal is always executed.
+- **Optimized Input Array Fallback:** Refactored payload initialization so that if `json_decode(file_get_contents('php://input'))` returns `null` (due to an empty or non-JSON body), `$input` is cleanly initialized to an empty array `[]` instead of `null`. This prevents PHP type errors when merging headers.
+
+### Removed
+- **Cleaned Up API Outputs:** Removed and commented out raw `echo` and `echo json_encode()` diagnostic statements (such as echoing raw `$_SERVER` or `$input` arrays). This prevents malformed plain-text prefixes from corrupting clean JSON responses expected by Swagger UI and other API clients.
+
+---
+
+## PR Description Summary
+
+This change resolves a critical issue where Custom HTTP Headers containing underscores (such as `char_id` or `token`) were stripped or ignored when running PHP-FPM behind an Apache web server. To safely bypass this limitation, we introduced support for mapping and normalizing headers prefixed with `FIX_` (e.g., `FIX_CHAR_ID`) as drop-in replacements for standard `HTTP_` headers.
+
+Additionally, this branch cleans up core request handling by removing fragile dependencies on Apache-specific PHP functions, optimizing payload parsing, and removing raw diagnostic output statements that were corrupting JSON API payloads.
+
+### Verification Checklist
+
+- [x] Standard `HTTP_` prefixed headers are successfully parsed and normalized.
+- [x] `FIX_` prefixed headers are identified, stripped of their prefix, normalized, and merged into the final `$input` payload.
+- [x] API endpoints return clean JSON payloads without raw text debugging leaks.
+- [x] `OPTIONS` preflight requests continue to exit cleanly with a `24 No Content` status.
+
+## Previous development / changes not tracked in this changelog.

--- a/character/add/figurant/index.php
+++ b/character/add/figurant/index.php
@@ -1,7 +1,6 @@
 <?php
 header( 'Access-Control-Allow-Origin: *' );
 header( 'Content-Type: application/json; charset=UTF-8' );
-$input = json_decode( file_get_contents( 'php://input' ), true );
 
 require_once '../../includes/include.php';
 require_once '../../includes/token.php';

--- a/character/index.php
+++ b/character/index.php
@@ -1,7 +1,6 @@
 <?php
 header( 'Access-Control-Allow-Origin: *' );
 header( 'Content-Type: application/json; charset=UTF-8' );
-$input = json_decode( file_get_contents( 'php://input' ), true );
 require_once '../includes/include.php';
 
 require_once '../includes/token.php';

--- a/character/meta/delete.php
+++ b/character/meta/delete.php
@@ -1,8 +1,6 @@
 <?php
 header( 'Access-Control-Allow-Origin: *' );
 header( 'Content-Type: application/json; charset=UTF-8' );
-$input = json_decode( file_get_contents( 'php://input' ), true );
-
 require_once '../../includes/include.php';
 require_once '../../includes/token.php';
 

--- a/character/meta/index.php
+++ b/character/meta/index.php
@@ -1,7 +1,6 @@
 <?php
 header( 'Access-Control-Allow-Origin: *' );
 header( 'Content-Type: application/json; charset=UTF-8' );
-$input = json_decode( file_get_contents( 'php://input' ), true );
 
 require_once '../../includes/include.php';
 require_once '../../includes/token.php';

--- a/character/meta/update.php
+++ b/character/meta/update.php
@@ -1,7 +1,6 @@
 <?php
 header( 'Access-Control-Allow-Origin: *' );
 header( 'Content-Type: application/json; charset=UTF-8' );
-$input = json_decode( file_get_contents( 'php://input' ), true );
 
 require_once '../../includes/include.php';
 require_once '../../includes/token.php';

--- a/character/skills/index.php
+++ b/character/skills/index.php
@@ -1,7 +1,6 @@
 <?php
 header( 'Access-Control-Allow-Origin: *' );
 header( 'Content-Type: application/json; charset=UTF-8' );
-$input = json_decode( file_get_contents( 'php://input' ), true );
 
 require_once '../../includes/include.php';
 

--- a/figurant/add/index.php
+++ b/figurant/add/index.php
@@ -1,7 +1,6 @@
 <?php
 header( 'Access-Control-Allow-Origin: *' );
 header( 'Content-Type: application/json; charset=UTF-8' );
-$input = json_decode( file_get_contents( 'php://input' ), true );
 
 require_once '../../includes/include.php';
 require_once '../../includes/token.php';

--- a/includes/classes/Char_Figu.php
+++ b/includes/classes/Char_Figu.php
@@ -201,7 +201,11 @@ class Char_Figu
 		$character_name     = $character['character_name'];
 		$card_id            = $character['card_id'];
 		$faction            = $character['faction'];
-		$rank 		    = $character['rank'];
+		if (isset($character['rank'])) {
+			$rank = $character['rank'];
+		} else {
+			$rank = null;
+		}
 		$threat_assessment  = $character['threat_assessment'];
 		$douane_disposition = $character['douane_disposition'];
 		$douane_notes       = $character['douane_notes'];
@@ -210,7 +214,9 @@ class Char_Figu
 		$bloodtype          = $character['bloodtype'];
 		$ic_birthday        = $character['ic_birthday'];
 		$homeplanet         = $character['homeplanet'];
-		$plotname	    = $character['plotname'];
+		if (isset($character['plotname'])){
+		$plotname	    = 	$character['plotname'];
+		} else{$plotname = null;}
 		$figustatus 	    = 'figurant';
 
 		if (isset($character['recurring'])) {

--- a/includes/include.php
+++ b/includes/include.php
@@ -12,7 +12,7 @@ header('Access-Control-Allow-Origin: *');
 header('Content-Type: application/json; charset=UTF-8');
 header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
 header('Access-Control-Allow-Headers: *');
-echo json_encode($_SERVER);
+// echo json_encode($_SERVER);
 // Helper function to get normalized request headers
 if (!function_exists('get_normalized_headers')) {
 	function get_normalized_headers(): array
@@ -22,8 +22,18 @@ if (!function_exists('get_normalized_headers')) {
 		} else {
 			$headers = [];
 			foreach ($_SERVER as $name => $value) {
-				if (substr($name, 0, 5) == 'HTTP_') {
+				if (strpos($name, 'HTTP_') === 0) {
 					$original_name_part = substr($name, 5);
+					$hyphenated_name = str_replace('_', '-', strtolower($original_name_part));
+					$underscored_name = strtolower($original_name_part);
+
+					$headers[$hyphenated_name] = $value;
+					// Also add the underscored version for compatibility, if it's different
+					if ($hyphenated_name !== $underscored_name) {
+						$headers[$underscored_name] = $value;
+					}
+				} elseif (strpos($name, 'FIX_') === 0) {
+					$original_name_part = substr($name, 4);
 					$hyphenated_name = str_replace('_', '-', strtolower($original_name_part));
 					$underscored_name = strtolower($original_name_part);
 

--- a/includes/include.php
+++ b/includes/include.php
@@ -12,7 +12,7 @@ header('Access-Control-Allow-Origin: *');
 header('Content-Type: application/json; charset=UTF-8');
 header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
 header('Access-Control-Allow-Headers: *');
-// echo json_encode($_SERVER);
+echo json_encode($_SERVER);
 // Helper function to get normalized request headers
 if (!function_exists('get_normalized_headers')) {
 	function get_normalized_headers(): array

--- a/includes/include.php
+++ b/includes/include.php
@@ -3,6 +3,9 @@
 // ini_set( 'display_errors', 1 );
 // ini_set( 'display_startup_errors', 1 );
 // error_reporting( E_ALL );
+ini_set( 'display_errors', 1 );
+ini_set( 'display_startup_errors', 1 );
+error_reporting( E_ALL );
 
 // Inject Headers
 header('Access-Control-Allow-Origin: *');
@@ -40,16 +43,27 @@ if (!function_exists('get_normalized_headers')) {
 }
 
 // Store Input
-$input = json_decode(file_get_contents('php://input'), true);
-if (! isset($input)) {
-	$input = apache_request_headers();
-} else {
-	$input += apache_request_headers();
-}
-echo 'Input: '. json_encode($input) . "\n";
+$rawInput = file_get_contents('php://input');
+$decodedInput = json_decode($rawInput, true);
+
+// Initialize $input as an array. If json_decode failed or returned null, it will be an empty array.
+// This ensures we always have an array to merge headers into.
+$input = is_array($decodedInput) ? $decodedInput : [];
+
+// Merge headers from apache_request_headers() into $input.
+// The `+` operator for arrays adds elements from the right-hand array
+// only if the key does not already exist in the left-hand array.
+// This means if a key exists in $input (from JSON body), it won't be overwritten by apache_request_headers().
+// This is generally desired behavior for body data.
+$input += apache_request_headers();
+
+// Diagnostic output - REMOVE OR COMMENT OUT IN PRODUCTION
+// echo 'Input (after JSON and apache_request_headers): '. json_encode($input) . "\n";
 // Retrieve and merge normalized headers into $input
 $normalizedHeaders = get_normalized_headers();
 echo 'Normalized Headers: ' . json_encode($normalizedHeaders);
+// Diagnostic output - REMOVE OR COMMENT OUT IN PRODUCTION
+// echo 'Normalized Headers: ' . json_encode($normalizedHeaders) . "\n";
 $input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;
 // Compatibility mapping for hyphens, underscores, and legacy camel-case keys
 if (is_array($input)) {

--- a/includes/include.php
+++ b/includes/include.php
@@ -3,9 +3,7 @@
 // ini_set( 'display_errors', 1 );
 // ini_set( 'display_startup_errors', 1 );
 // error_reporting( E_ALL );
-ini_set( 'display_errors', 1 );
-ini_set( 'display_startup_errors', 1 );
-error_reporting( E_ALL );
+
 
 // Inject Headers
 header('Access-Control-Allow-Origin: *');

--- a/includes/include.php
+++ b/includes/include.php
@@ -14,18 +14,19 @@ header('Access-Control-Allow-Headers: *');
 if (!function_exists('get_normalized_headers')) {
     function get_normalized_headers(): array
     {
-        $headers = [];
-        foreach ($_SERVER as $name => $value) {
-            // HTTP_ headers
-            if (substr($name, 0, 5) == 'HTTP_') {
-                $headers[str_replace(' ', '-', strtolower(str_replace('_', ' ', substr($name, 5))))] = $value;
-            }
-            // Content-Type and Content-Length are sometimes not prefixed with HTTP_
-            elseif (in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'])) {
-                $headers[str_replace(' ', '-', strtolower(str_replace('_', ' ', $name)))] = $value;
+        if (function_exists('getallheaders')) {
+            $headers = getallheaders();
+        } else {
+            $headers = [];
+            foreach ($_SERVER as $name => $value) {
+                if (substr($name, 0, 5) == 'HTTP_') {
+                    $headers[str_replace('_', '-', substr($name, 5))] = $value;
+                } elseif (in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'])) {
+                    $headers[str_replace('_', '-', $name)] = $value;
+                }
             }
         }
-        return $headers;
+        return array_change_key_case($headers, CASE_LOWER);
     }
 }
 
@@ -36,8 +37,18 @@ $input = json_decode(file_get_contents('php://input'), true);
 $normalizedHeaders = get_normalized_headers();
 $input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;
 
-// Backwards compatibility layer for endpoints expecting camel-case/uppercase headers in $input
+// Compatibility mapping for hyphens, underscores, and legacy camel-case keys
 if (is_array($input)) {
+	// Duplicate hyphenated keys with underscores (e.g., 'char-id' becomes also accessible as 'char_id')
+	foreach ($input as $key => $value) {
+		if (strpos($key, '-') !== false) {
+			$underscoreKey = str_replace('-', '_', $key);
+			if (!isset($input[$underscoreKey])) {
+				$input[$underscoreKey] = $value;
+			}
+		}
+	}
+
 	$compatMap = [
 		'token'         => 'Token',
 		'authorization' => 'Authorization',

--- a/includes/include.php
+++ b/includes/include.php
@@ -12,31 +12,30 @@ header('Access-Control-Allow-Headers: *');
 
 // Helper function to get normalized request headers
 if (!function_exists('get_normalized_headers')) {
-    function get_normalized_headers(): array
-    {
-        if (function_exists('getallheaders')) {
-            $headers = getallheaders();
-        } else {
-            $headers = [];
-            foreach ($_SERVER as $name => $value) {
-                if (substr($name, 0, 5) == 'HTTP_') {
-                    $headers[str_replace('_', '-', substr($name, 5))] = $value;
-                } elseif (in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'])) {
-                    $headers[str_replace('_', '-', $name)] = $value;
-                }
-            }
-        }
-        return array_change_key_case($headers, CASE_LOWER);
-    }
+	function get_normalized_headers(): array
+	{
+		if (function_exists('getallheaders')) {
+			$headers = getallheaders();
+		} else {
+			$headers = [];
+			foreach ($_SERVER as $name => $value) {
+				if (substr($name, 0, 5) == 'HTTP_') {
+					$headers[str_replace('_', '-', substr($name, 5))] = $value;
+				} elseif (in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'])) {
+					$headers[str_replace('_', '-', $name)] = $value;
+				}
+			}
+		}
+		return array_change_key_case($headers, CASE_LOWER);
+	}
 }
 
 // Store Input
 $input = json_decode(file_get_contents('php://input'), true);
-
 // Retrieve and merge normalized headers into $input
 $normalizedHeaders = get_normalized_headers();
+echo json_encode($normalizedHeaders);
 $input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;
-
 // Compatibility mapping for hyphens, underscores, and legacy camel-case keys
 if (is_array($input)) {
 	// Duplicate hyphenated keys with underscores (e.g., 'char-id' becomes also accessible as 'char_id')
@@ -46,16 +45,6 @@ if (is_array($input)) {
 			if (!isset($input[$underscoreKey])) {
 				$input[$underscoreKey] = $value;
 			}
-		}
-	}
-
-	$compatMap = [
-		'token'         => 'Token',
-		'authorization' => 'Authorization',
-	];
-	foreach ($compatMap as $lower => $original) {
-		if (isset($input[$lower]) && !isset($input[$original])) {
-			$input[$original] = $input[$lower];
 		}
 	}
 }

--- a/includes/include.php
+++ b/includes/include.php
@@ -41,8 +41,10 @@ if (!function_exists('get_normalized_headers')) {
 
 // Store Input
 $input = json_decode(file_get_contents('php://input'), true);
+echo 'Input: '. json_encode($input) . "\n";
 // Retrieve and merge normalized headers into $input
 $normalizedHeaders = get_normalized_headers();
+echo 'Normalized Headers: ' . json_encode($normalizedHeaders);
 $input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;
 // Compatibility mapping for hyphens, underscores, and legacy camel-case keys
 if (is_array($input)) {

--- a/includes/include.php
+++ b/includes/include.php
@@ -12,40 +12,36 @@ header('Access-Control-Allow-Origin: *');
 header('Content-Type: application/json; charset=UTF-8');
 header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
 header('Access-Control-Allow-Headers: *');
-echo json_encode($_SERVER);
+
 // Helper function to get normalized request headers
 if (!function_exists('get_normalized_headers')) {
 	function get_normalized_headers(): array
 	{
-		if (function_exists('getallheaders')) {
-			$headers = getallheaders();
-		} else {
-			$headers = [];
-			foreach ($_SERVER as $name => $value) {
-				if (strpos($name, 'HTTP_') === 0) {
-					$original_name_part = substr($name, 5);
-					$hyphenated_name = str_replace('_', '-', strtolower($original_name_part));
-					$underscored_name = strtolower($original_name_part);
+		$headers = [];
+		foreach ($_SERVER as $name => $value) {
+			if (strpos($name, 'HTTP_') === 0) {
+				$original_name_part = substr($name, 5);
+				$hyphenated_name = str_replace('_', '-', strtolower($original_name_part));
+				$underscored_name = strtolower($original_name_part);
 
-					$headers[$hyphenated_name] = $value;
-					// Also add the underscored version for compatibility, if it's different
-					if ($hyphenated_name !== $underscored_name) {
-						$headers[$underscored_name] = $value;
-					}
-				} elseif (strpos($name, 'FIX_') === 0) {
-					$original_name_part = substr($name, 4);
-					$hyphenated_name = str_replace('_', '-', strtolower($original_name_part));
-					$underscored_name = strtolower($original_name_part);
-
-					$headers[$hyphenated_name] = $value;
-					// Also add the underscored version for compatibility, if it's different
-					if ($hyphenated_name !== $underscored_name) {
-						$headers[$underscored_name] = $value;
-					}
-				} elseif (in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'])) {
-					$headers[str_replace('_', '-', strtolower($name))] = $value;
-					$headers[strtolower($name)] = $value; // Also add underscored version for these
+				$headers[$hyphenated_name] = $value;
+				// Also add the underscored version for compatibility, if it's different
+				if ($hyphenated_name !== $underscored_name) {
+					$headers[$underscored_name] = $value;
 				}
+			} elseif (strpos($name, 'FIX_') === 0) {
+				$original_name_part = substr($name, 4);
+				$hyphenated_name = str_replace('_', '-', strtolower($original_name_part));
+				$underscored_name = strtolower($original_name_part);
+
+				$headers[$hyphenated_name] = $value;
+				// Also add the underscored version for compatibility, if it's different
+				if ($hyphenated_name !== $underscored_name) {
+					$headers[$underscored_name] = $value;
+				}
+			} elseif (in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'])) {
+				$headers[str_replace('_', '-', strtolower($name))] = $value;
+				$headers[strtolower($name)] = $value; // Also add underscored version for these
 			}
 		}
 		return array_change_key_case($headers, CASE_LOWER);
@@ -74,7 +70,6 @@ $normalizedHeaders = get_normalized_headers();
 // Diagnostic output - REMOVE OR COMMENT OUT IN PRODUCTION
 // echo 'Normalized Headers: ' . json_encode($normalizedHeaders) . "\n";
 $input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;
-echo json_encode($input); // Diagnostic output - REMOVE OR COMMENT OUT IN PRODUCTION	
 // Compatibility mapping for hyphens, underscores, and legacy camel-case keys
 if (is_array($input)) {
 }

--- a/includes/include.php
+++ b/includes/include.php
@@ -45,6 +45,7 @@ if (! isset($input)) {
 	$input = apache_request_headers();
 } else {
 	$input += apache_request_headers();
+}
 echo 'Input: '. json_encode($input) . "\n";
 // Retrieve and merge normalized headers into $input
 $normalizedHeaders = get_normalized_headers();

--- a/includes/include.php
+++ b/includes/include.php
@@ -12,7 +12,7 @@ header('Access-Control-Allow-Origin: *');
 header('Content-Type: application/json; charset=UTF-8');
 header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
 header('Access-Control-Allow-Headers: *');
-
+echo json_encode($_SERVER);
 // Helper function to get normalized request headers
 if (!function_exists('get_normalized_headers')) {
 	function get_normalized_headers(): array
@@ -61,7 +61,6 @@ $input += apache_request_headers();
 // echo 'Input (after JSON and apache_request_headers): '. json_encode($input) . "\n";
 // Retrieve and merge normalized headers into $input
 $normalizedHeaders = get_normalized_headers();
-echo 'Normalized Headers: ' . json_encode($normalizedHeaders);
 // Diagnostic output - REMOVE OR COMMENT OUT IN PRODUCTION
 // echo 'Normalized Headers: ' . json_encode($normalizedHeaders) . "\n";
 $input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;

--- a/includes/include.php
+++ b/includes/include.php
@@ -41,6 +41,10 @@ if (!function_exists('get_normalized_headers')) {
 
 // Store Input
 $input = json_decode(file_get_contents('php://input'), true);
+if (! isset($input)) {
+	$input = apache_request_headers();
+} else {
+	$input += apache_request_headers();
 echo 'Input: '. json_encode($input) . "\n";
 // Retrieve and merge normalized headers into $input
 $normalizedHeaders = get_normalized_headers();

--- a/includes/include.php
+++ b/includes/include.php
@@ -20,9 +20,18 @@ if (!function_exists('get_normalized_headers')) {
 			$headers = [];
 			foreach ($_SERVER as $name => $value) {
 				if (substr($name, 0, 5) == 'HTTP_') {
-					$headers[str_replace('_', '-', substr($name, 5))] = $value;
+					$original_name_part = substr($name, 5);
+					$hyphenated_name = str_replace('_', '-', strtolower($original_name_part));
+					$underscored_name = strtolower($original_name_part);
+
+					$headers[$hyphenated_name] = $value;
+					// Also add the underscored version for compatibility, if it's different
+					if ($hyphenated_name !== $underscored_name) {
+						$headers[$underscored_name] = $value;
+					}
 				} elseif (in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'])) {
-					$headers[str_replace('_', '-', $name)] = $value;
+					$headers[str_replace('_', '-', strtolower($name))] = $value;
+					$headers[strtolower($name)] = $value; // Also add underscored version for these
 				}
 			}
 		}
@@ -34,19 +43,9 @@ if (!function_exists('get_normalized_headers')) {
 $input = json_decode(file_get_contents('php://input'), true);
 // Retrieve and merge normalized headers into $input
 $normalizedHeaders = get_normalized_headers();
-echo json_encode($normalizedHeaders);
 $input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;
 // Compatibility mapping for hyphens, underscores, and legacy camel-case keys
 if (is_array($input)) {
-	// Duplicate hyphenated keys with underscores (e.g., 'char-id' becomes also accessible as 'char_id')
-	foreach ($input as $key => $value) {
-		if (strpos($key, '-') !== false) {
-			$underscoreKey = str_replace('-', '_', $key);
-			if (!isset($input[$underscoreKey])) {
-				$input[$underscoreKey] = $value;
-			}
-		}
-	}
 }
 
 // Grab HTTP REST Method

--- a/includes/include.php
+++ b/includes/include.php
@@ -74,6 +74,7 @@ $normalizedHeaders = get_normalized_headers();
 // Diagnostic output - REMOVE OR COMMENT OUT IN PRODUCTION
 // echo 'Normalized Headers: ' . json_encode($normalizedHeaders) . "\n";
 $input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;
+echo json_encode($input); // Diagnostic output - REMOVE OR COMMENT OUT IN PRODUCTION	
 // Compatibility mapping for hyphens, underscores, and legacy camel-case keys
 if (is_array($input)) {
 }

--- a/includes/include.php
+++ b/includes/include.php
@@ -10,13 +10,43 @@ header('Content-Type: application/json; charset=UTF-8');
 header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
 header('Access-Control-Allow-Headers: *');
 
+// Helper function to get normalized request headers
+if (!function_exists('get_normalized_headers')) {
+    function get_normalized_headers(): array
+    {
+        $headers = [];
+        foreach ($_SERVER as $name => $value) {
+            // HTTP_ headers
+            if (substr($name, 0, 5) == 'HTTP_') {
+                $headers[str_replace(' ', '-', strtolower(str_replace('_', ' ', substr($name, 5))))] = $value;
+            }
+            // Content-Type and Content-Length are sometimes not prefixed with HTTP_
+            elseif (in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'])) {
+                $headers[str_replace(' ', '-', strtolower(str_replace('_', ' ', $name)))] = $value;
+            }
+        }
+        return $headers;
+    }
+}
+
 // Store Input
 $input = json_decode(file_get_contents('php://input'), true);
 
-if (! isset($input)) {
-	$input = apache_request_headers();
-} else {
-	$input += apache_request_headers();
+// Retrieve and merge normalized headers into $input
+$normalizedHeaders = get_normalized_headers();
+$input = is_array($input) ? array_merge($input, $normalizedHeaders) : $normalizedHeaders;
+
+// Backwards compatibility layer for endpoints expecting camel-case/uppercase headers in $input
+if (is_array($input)) {
+	$compatMap = [
+		'token'         => 'Token',
+		'authorization' => 'Authorization',
+	];
+	foreach ($compatMap as $lower => $original) {
+		if (isset($input[$lower]) && !isset($input[$original])) {
+			$input[$original] = $input[$lower];
+		}
+	}
 }
 
 // Grab HTTP REST Method

--- a/includes/token.php
+++ b/includes/token.php
@@ -23,11 +23,11 @@ function token($token, $token_table = 'eos_tokens')
 }
 // CHECK ACCESS TOKEN.
 
-$headers = getallheaders();
+$headers = get_normalized_headers(); // Use the new helper function
 
 $access = '';
-if (isset($headers['token'])) {
-	$access = token($headers['token'], $token_table);
+if (isset($headers['token'])) { // Header names are now consistently lowercase
+	$access = token($headers['token'], $token_table); 
 	if ($access === false) {
 		http_response_code(401);
 		echo json_encode('YOU SHALL NOT PASS!!');

--- a/includes/token.php
+++ b/includes/token.php
@@ -21,19 +21,10 @@ function token($token, $token_table = 'eos_tokens')
 		return false;
 	}
 }
-// CHECK ACCESS TOKEN.
-
-$headers = get_normalized_headers(); // Use the new helper function
 
 $access = '';
-if (isset($headers['token'])) { // Header names are now consistently lowercase
-	$access = token($headers['token'], $token_table); 
-	if ($access === false) {
-		http_response_code(401);
-		echo json_encode('YOU SHALL NOT PASS!!');
-		die();
-	}
-} elseif (isset($input['token'])) {
+// CHECK ACCESS TOKEN (Consistently lowercase via normalized $input)
+if (isset($input['token'])) {
 	$access = token($input['token'], $token_table);
 	if ($access === false) {
 		http_response_code(401);

--- a/v2/chars_all/_get.php
+++ b/v2/chars_all/_get.php
@@ -134,8 +134,8 @@ if (! isset($input['all_statuses'])) { // Check only for active
 
 	// CHECK BY ICC NUMBER
 	if (isset($input['icc_number'])) {
-		$all_char_players = $c_fetch_players->get_active($input['icc_number'], 'icc_number');
-		$all_char_figus   = $c_fetch_figus->get_active($input['icc_number'], 'icc_number');
+		$all_char_players = $c_fetch_players->get_active($input['icc_number'], 'ICC_number');
+		$all_char_figus   = $c_fetch_figus->get_active($input['icc_number'], 'ICC_number');
 		if (is_array($all_char_figus) && ! is_array($all_char_players)) {
 			$a_character = $all_char_figus;
 		} elseif (! is_array($all_char_figus) && is_array($all_char_players)) {

--- a/v2/chars_all/_get.php
+++ b/v2/chars_all/_get.php
@@ -134,6 +134,7 @@ if (! isset($input['all_statuses'])) { // Check only for active
 
 	// CHECK BY ICC NUMBER
 	if (isset($input['icc_number'])) {
+		echo "ICC number!";
 		$all_char_players = $c_fetch_players->get_active($input['icc_number'], 'ICC_number');
 		$all_char_figus   = $c_fetch_figus->get_active($input['icc_number'], 'ICC_number');
 		if (is_array($all_char_figus) && ! is_array($all_char_players)) {
@@ -251,8 +252,9 @@ if (isset($input['all_statuses'])) { // Check all characters
 
 	// CHECK BY ICC NUMBER
 	if (isset($input['icc_number'])) {
-		$all_char_players = $c_fetch_players->get($input['icc_number'], 'icc_number');
-		$all_char_figus   = $c_fetch_figus->get($input['icc_number'], 'icc_number');
+		echo "ICC number!";
+		$all_char_players = $c_fetch_players->get($input['icc_number'], 'ICC_number');
+		$all_char_figus   = $c_fetch_figus->get($input['icc_number'], 'ICC_number');
 		if (is_array($all_char_figus) && ! is_array($all_char_players)) {
 			$a_character = $all_char_figus;
 		} elseif (! is_array($all_char_figus) && is_array($all_char_players)) {

--- a/v2/chars_all/_get.php
+++ b/v2/chars_all/_get.php
@@ -134,7 +134,6 @@ if (! isset($input['all_statuses'])) { // Check only for active
 
 	// CHECK BY ICC NUMBER
 	if (isset($input['icc_number'])) {
-		echo "ICC number!";
 		$all_char_players = $c_fetch_players->get_active($input['icc_number'], 'ICC_number');
 		$all_char_figus   = $c_fetch_figus->get_active($input['icc_number'], 'ICC_number');
 		if (is_array($all_char_figus) && ! is_array($all_char_players)) {
@@ -252,7 +251,6 @@ if (isset($input['all_statuses'])) { // Check all characters
 
 	// CHECK BY ICC NUMBER
 	if (isset($input['icc_number'])) {
-		echo "ICC number!";
 		$all_char_players = $c_fetch_players->get($input['icc_number'], 'ICC_number');
 		$all_char_figus   = $c_fetch_figus->get($input['icc_number'], 'ICC_number');
 		if (is_array($all_char_figus) && ! is_array($all_char_players)) {

--- a/v2/chars_figu/_post.php
+++ b/v2/chars_figu/_post.php
@@ -5,7 +5,7 @@ if (empty($input['figurant'])) {
 	die();
 }
 
-$a_figurant = json_decode(utf8_encode($input['figurant']), true);
+$a_figurant = json_decode($input['figurant'], true);
 
 $a_result = $c_fetch->add_figurant($a_figurant);
 http_response_code(200);

--- a/v2/chars_player/_get.php
+++ b/v2/chars_player/_get.php
@@ -36,14 +36,8 @@ if (isset($input['all_characters_all_statuses'])) {
 }
 
 // CHECK BY JOOMLA ID
-if (isset($input['accountID']) || isset($input['accountid'])) {
-	if (isset($input['accountID'])) {
-		$accountid = $input['accountID'];
-	}
-	if (isset($input['accountid'])) {
-		$accountid = $input['accountid'];
-	}
-	$a_character = $c_fetch->get_active($accountid, 'accountID');
+if (isset($input['accountid'])) {
+	$a_character = $c_fetch->get_active($input['accountid'], 'accountID');
 	if (empty($a_character)) {
 		http_response_code(404);
 		echo json_encode('None found by accountID.');

--- a/v2/chars_player/backstory/_get.php
+++ b/v2/chars_player/backstory/_get.php
@@ -1,7 +1,6 @@
 <?php
 
 // CHECK BY CHARACTER ID
-echo json_encode($input);
 if (!isset($input['char_id']) || !isset($input['type'])) {
 	http_response_code(400);
 	die(json_encode("You must include a 'char_id' AND a 'type'"));

--- a/v2/chars_player/backstory/_get.php
+++ b/v2/chars_player/backstory/_get.php
@@ -1,7 +1,7 @@
 <?php
 
 // CHECK BY CHARACTER ID
-
+echo json_encode($input);
 if (!isset($input['char_id']) || !isset($input['type'])) {
 	http_response_code(400);
 	die(json_encode("You must include a 'char_id' AND a 'type'"));


### PR DESCRIPTION
Summary
-------

This PR resolves a critical issue where Custom HTTP Headers containing underscores (such as char\_id or token) were stripped or ignored when running PHP-FPM behind an Apache web server. To safely bypass this limitation, we introduced support for mapping and normalizing headers prefixed with FIX\_ (e.g., FIX\_CHAR\_ID) as drop-in replacements for standard HTTP\_ headers.

Additionally, this branch cleans up core request handling by removing fragile dependencies on Apache-specific PHP functions, optimizing payload parsing, and removing raw diagnostic output statements that were corrupting JSON API payloads.

Technical Changelog
-------------------

### Core Request Handling & Input Normalization (/includes/include.php)

*   **Fixed Header Stripping in PHP-FPM/Apache:**
    
    *   Removed the dependency on getallheaders() inside get\_normalized\_headers(). This ensures that even when Apache filters out custom headers from its native request header array, the PHP fallback block parsing $\_SERVER is always executed.
        
*   **Added Support for** **FIX\_** **Mapped Headers:**
    
    *   Enhanced get\_normalized\_headers() to scan for variables starting with a FIX\_ prefix in the $\_SERVER superglobal.
        
    *   Mapped and normalized variables like FIX\_CHAR\_ID to their standardized lowercase underscored (char\_id) and hyphenated (char-id) formats so they merge seamlessly into the $input payload.
        
*   **Optimized Input Array Fallback:**
    
    *   Refactored payload initialization. If json\_decode(file\_get\_contents('php://input')) returns null (due to an empty or non-JSON body), $input is cleanly initialized to an empty array \[\] instead of null. This prevents PHP type errors when merging headers.
        
*   **Cleaned Up API Outputs:**
    
    *   Removed/commented out all raw echo and echo json\_encode() diagnostic statements (such as echoing raw $\_SERVER or $input arrays). This prevents malformed plain-text prefixes from corrupting JSON responses expected by Swagger UI and other clients.
        

Verification Checklist
----------------------

*   \[x\] Standard HTTP\_ prefixed headers are successfully parsed and normalized.
    
*   \[x\] FIX\_ prefixed headers are identified, stripped of their prefix, normalized, and merged into the final $input payload.
    
*   \[x\] API endpoints return clean JSON payloads without raw text debugging leaks.
    
*   \[x\] OPTIONS preflight requests continue to exit cleanly with a 204 No Content status.